### PR TITLE
Use Deploy environment secrets in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
   deploy:
     name: Deploy to remote server
     runs-on: ubuntu-latest
+    environment:
+      name: Deploy
 
     steps:
       - name: Validate required secrets

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Деплой запускается вручную через GitHub Actions workflow **Deploy over SSH**.
 
-Для workflow нужны GitHub Secrets:
+Для workflow нужны GitHub Environment Secrets в environment **Deploy**:
 
 - `DEPLOY_HOST` - адрес сервера;
 - `DEPLOY_USER` - SSH-пользователь;


### PR DESCRIPTION
## What changed

- Attached the deploy job to the GitHub Environment named `Deploy`, so environment secrets are available to the workflow.
- Clarified in README that deploy secrets must be created as GitHub Environment Secrets in `Deploy`.

## Root cause

The repository has no repository-level secrets, while the deploy secrets were created under the `Deploy` environment. Without `jobs.deploy.environment`, `${{ secrets.DEPLOY_HOST }}` resolves to an empty value and the validation step fails.

## Validation

- `uv run pre-commit run --files .github/workflows/deploy.yml README.md`

## Follow-up required

The `Deploy` environment currently has `DEPLOY_HOST`, `DEPLOY_PATH`, `DEPLOY_PORT`, and `DEPLOY_SSH_KEY`. It is missing `DEPLOY_USER`; the workflow will fail at the next validation step until that secret is added.