### PR TITLE
Add scheduled subscription broadcasts

### DIFF
--- a/src/cringe_pics_telebot/bot/__init__.py
+++ b/src/cringe_pics_telebot/bot/__init__.py
@@ -1,8 +1,6 @@
 from .bot import create_bot, dp
-from .polling import start_polling
 
 __all__ = [
     "create_bot",
     "dp",
-    "start_polling",
 ]

--- a/src/cringe_pics_telebot/bot/images.py
+++ b/src/cringe_pics_telebot/bot/images.py
@@ -3,29 +3,24 @@ import logging
 from aiogram import F, Router
 from aiogram.filters import Command
 from aiogram.types import (
-    BufferedInputFile,
     CallbackQuery,
     InaccessibleMessage,
-    InputMedia,
-    InputMediaAnimation,
-    InputMediaPhoto,
     Message,
 )
 
-from cringe_pics_telebot.bot.helpers import HasFileId
 from cringe_pics_telebot.bot.keyboards import (
     create_inline_subscriptions_keyboard,
     create_reply_keyboard,
 )
+from cringe_pics_telebot.bot.media import add_image_to_message, get_message_media_file_id
 from cringe_pics_telebot.bot.subscription_callback_data import SubscriptionCallbackData
 from cringe_pics_telebot.repositories.postgres import SubscriptionType
 from cringe_pics_telebot.repositories.postgres.connection import (
     transaction,
 )
 from cringe_pics_telebot.services.random_image import (
-    CachedImage,
-    DownloadedImage,
-    download_image,
+    CachedMedia,
+    DownloadedMedia,
     get_random_image,
     update_image_cache,
 )
@@ -174,15 +169,7 @@ async def send_image(message: Message, *, subscription_type: SubscriptionType) -
         return
 
     try:
-        media: HasFileId
-        if edited_message.photo is not None:
-            media, *_ = edited_message.photo
-        elif edited_message.animation is not None:
-            media = edited_message.animation
-        else:
-            raise ValueError("Resulted message %s has no media", edited_message.message_id)
-
-        await update_image_cache(image_path=image.path, image_id=media.file_id)
+        await update_image_cache(image_path=image.path, image_id=get_message_media_file_id(edited_message))
     except Exception:
         logger.exception("Failed to update image %s in cache", image.path)
 
@@ -192,35 +179,8 @@ async def unknown_message(message: Message) -> None:
     await handle_start(message)
 
 
-async def _add_image_to_message(*, message: Message, image: DownloadedImage | CachedImage) -> Message | bool:
-    input_media_type: type[InputMedia]
-    if "gif" in image.mime_type:
-        filename = f"{image.name}.gif"
-        input_media_type = InputMediaAnimation
-    else:
-        filename = image.name
-        input_media_type = InputMediaPhoto
-
-    added_cached_image = False
-    if isinstance(image, CachedImage):
-        try:
-            edited_message = await message.edit_media(input_media_type(media=image.id))
-            logger.info("Added cached image %s from cache", image.path)
-        except Exception:
-            logger.exception("Failed to attach cached image %s to message %s", image.id, message.message_id)
-        else:
-            added_cached_image = True
-
-    if not added_cached_image:
-        image_data = image.data if isinstance(image, DownloadedImage) else await download_image(image.path)
-        edited_message = await message.edit_media(input_media_type(media=BufferedInputFile(image_data, filename)))
-        logger.info("Downloaded and added image %s", image.path)
-
-    return edited_message
-
-
-async def _add_image_to_chat_message(*, message: Message, image: DownloadedImage | CachedImage) -> Message:
-    result = await _add_image_to_message(message=message, image=image)
+async def _add_image_to_chat_message(*, message: Message, image: DownloadedMedia | CachedMedia) -> Message:
+    result = await add_image_to_message(message=message, image=image)
 
     assert isinstance(result, Message)
     return result

--- a/src/cringe_pics_telebot/bot/media.py
+++ b/src/cringe_pics_telebot/bot/media.py
@@ -1,0 +1,80 @@
+import logging
+
+from aiogram import Bot
+from aiogram.types import (
+    BufferedInputFile,
+    InputMediaAnimation,
+    InputMediaPhoto,
+    Message,
+)
+
+from cringe_pics_telebot.bot.helpers import HasFileId
+from cringe_pics_telebot.services.random_image import CachedMedia, DownloadedMedia, download_image
+
+logger = logging.getLogger(__name__)
+
+
+async def add_image_to_message(*, message: Message, image: DownloadedMedia | CachedMedia) -> Message | bool:
+    added_cached_image = False
+    if isinstance(image, CachedMedia):
+        try:
+            edited_message = await message.edit_media(_input_media(image=image, media=image.id))
+            logger.info("Added cached image %s from cache", image.path)
+        except Exception:
+            logger.exception("Failed to attach cached image %s to message %s", image.id, message.message_id)
+        else:
+            added_cached_image = True
+
+    if not added_cached_image:
+        edited_message = await message.edit_media(_input_media(image=image, media=await _image_file(image)))
+        logger.info("Downloaded and added image %s", image.path)
+
+    return edited_message
+
+
+async def send_image_to_chat(*, bot: Bot, chat_id: int, image: DownloadedMedia | CachedMedia) -> Message:
+    media = image.id if isinstance(image, CachedMedia) else await _image_file(image)
+
+    if _is_animation(image):
+        return await bot.send_animation(chat_id=chat_id, animation=media)
+
+    return await bot.send_photo(chat_id=chat_id, photo=media)
+
+
+def get_message_media_file_id(message: Message) -> str:
+    media: HasFileId
+    if message.photo is not None:
+        media, *_ = message.photo
+    elif message.animation is not None:
+        media = message.animation
+    else:
+        raise ValueError("Resulted message %s has no media", message.message_id)
+
+    return media.file_id
+
+
+def _input_media(
+    *,
+    image: DownloadedMedia | CachedMedia,
+    media: str | BufferedInputFile,
+) -> InputMediaAnimation | InputMediaPhoto:
+    if _is_animation(image):
+        return InputMediaAnimation(media=media)
+
+    return InputMediaPhoto(media=media)
+
+
+async def _image_file(image: DownloadedMedia | CachedMedia) -> BufferedInputFile:
+    image_data = image.data if isinstance(image, DownloadedMedia) else await download_image(image.path)
+    return BufferedInputFile(image_data, _image_filename(image))
+
+
+def _image_filename(image: DownloadedMedia | CachedMedia) -> str:
+    if _is_animation(image):
+        return f"{image.name}.gif"
+
+    return image.name
+
+
+def _is_animation(image: DownloadedMedia | CachedMedia) -> bool:
+    return "gif" in image.mime_type

--- a/src/cringe_pics_telebot/bot/polling.py
+++ b/src/cringe_pics_telebot/bot/polling.py
@@ -1,13 +1,16 @@
+import asyncio
 import logging
 import os
 from collections.abc import AsyncGenerator
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager, suppress
+from datetime import timedelta
 
-from cringe_pics_telebot.bot import create_bot, dp
+from cringe_pics_telebot.bot.bot import create_bot, dp
 from cringe_pics_telebot.repositories.postgres import connect as connect_postgres
 from cringe_pics_telebot.repositories.postgres import create_tables
 from cringe_pics_telebot.repositories.redis import connect as connect_redis
 from cringe_pics_telebot.repositories.yandex import connect as connect_yandex
+from cringe_pics_telebot.services.subscription_broadcasts import DEFAULT_CHECK_INTERVAL, run_subscription_broadcasts
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -83,4 +86,18 @@ async def start_polling() -> None:
         except KeyError:
             logger.exception("Failed to get Telegram bot token")
             raise
-        await dp.start_polling(bot)
+        broadcast_interval = float(
+            os.environ.get("SUBSCRIPTION_BROADCAST_INTERVAL_SECONDS", DEFAULT_CHECK_INTERVAL.total_seconds())
+        )
+        broadcast_task = asyncio.create_task(
+            run_subscription_broadcasts(
+                bot,
+                interval=timedelta(seconds=broadcast_interval),
+            )
+        )
+        try:
+            await dp.start_polling(bot)
+        finally:
+            broadcast_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await broadcast_task

--- a/src/cringe_pics_telebot/cli.py
+++ b/src/cringe_pics_telebot/cli.py
@@ -2,7 +2,7 @@ import asyncio
 
 import click
 
-from cringe_pics_telebot.bot import start_polling
+from cringe_pics_telebot.bot.polling import start_polling
 
 
 @click.command()

--- a/src/cringe_pics_telebot/repositories/postgres/__init__.py
+++ b/src/cringe_pics_telebot/repositories/postgres/__init__.py
@@ -10,6 +10,7 @@ from .entities import SubscriptionType as SubscriptionType
 from .entities import User as User
 from .subscription import create_subscription as create_subscription
 from .subscription import delete_subscription as delete_subscription
+from .subscription import get_subscription_user_ids as get_subscription_user_ids
 from .subscription import get_user_subscriptions as get_user_subscriptions
 from .subscription_types import get_subscription_types as get_subscription_types
 from .users import create_user as create_user

--- a/src/cringe_pics_telebot/repositories/postgres/subscription.py
+++ b/src/cringe_pics_telebot/repositories/postgres/subscription.py
@@ -60,6 +60,20 @@ async def get_user_subscriptions(user_id: int) -> list[SubscriptionInfo]:
         ]
 
 
+async def get_subscription_user_ids(subscription_type_id: int) -> list[int]:
+    async with get_connection() as conn:
+        rows = (
+            await conn.execute(
+                select(s.c.user_id)
+                .where(s.c.subscription_type_id == subscription_type_id)
+                .distinct()
+                .order_by(s.c.user_id)
+            )
+        ).fetchall()
+
+        return [row.user_id for row in rows]
+
+
 async def delete_subscription(*, user_id: int, subscription_type_id: int) -> None:
     async with get_connection() as conn:
         await conn.execute(

--- a/src/cringe_pics_telebot/repositories/redis/__init__.py
+++ b/src/cringe_pics_telebot/repositories/redis/__init__.py
@@ -1,10 +1,11 @@
 from .connection import RedisConnectionError, RedisError, connect, get_connection
-from .repo import cached, get, set
+from .repo import cached, get, set, set_if_absent
 
 __all__ = [
     "connect",
     "get_connection",
     "set",
+    "set_if_absent",
     "get",
     "cached",
     "RedisError",

--- a/src/cringe_pics_telebot/repositories/redis/repo.py
+++ b/src/cringe_pics_telebot/repositories/redis/repo.py
@@ -38,6 +38,19 @@ async def set[T](*, key: str, value: T, cls: type[T], ttl: timedelta | None = No
             raise
 
 
+async def set_if_absent[T](*, key: str, value: T, cls: type[T], ttl: timedelta | None = None) -> bool:
+    async with get_connection() as conn:
+        serializer = get_serializer(cls)
+
+        try:
+            result = await conn.set(name=key, value=json.dumps(serializer.dump(value)), ex=ttl, nx=True)
+        except Exception:
+            logger.exception("Tried to serialize %s", value)
+            raise
+
+        return bool(result)
+
+
 async def get[T](*, key: str, cls: type[T]) -> T | None:
     async with get_connection() as conn:
         value = await conn.get(name=key)

--- a/src/cringe_pics_telebot/services/random_image.py
+++ b/src/cringe_pics_telebot/services/random_image.py
@@ -9,18 +9,18 @@ from cringe_pics_telebot.repositories.yandex import download_file as download_fi
 
 
 @dataclass
-class DownloadedImage(Image):
+class DownloadedMedia(Image):
     data: bytes
     """Данные скачанной картинки"""
 
 
 @dataclass
-class CachedImage(Image):
+class CachedMedia(Image):
     id: str
     """ID of picture on Telegram servers"""
 
 
-async def get_random_image(category_id: int | None = None) -> DownloadedImage | CachedImage:
+async def get_random_image(category_id: int | None = None) -> DownloadedMedia | CachedMedia:
     subscription_types = {subscription.id: subscription for subscription in await get_subscription_types()}
     if category_id is None:
         category = random.choice(list(subscription_types.values()))
@@ -32,7 +32,7 @@ async def get_random_image(category_id: int | None = None) -> DownloadedImage | 
     image_data = await get_image_by_path(random_image.path)
     match image_data:
         case bytes():
-            return DownloadedImage(
+            return DownloadedMedia(
                 name=random_image.name,
                 mime_type=random_image.mime_type,
                 path=random_image.path,
@@ -40,7 +40,7 @@ async def get_random_image(category_id: int | None = None) -> DownloadedImage | 
             )
 
         case str():
-            return CachedImage(
+            return CachedMedia(
                 name=random_image.name,
                 mime_type=random_image.mime_type,
                 path=random_image.path,

--- a/src/cringe_pics_telebot/services/subscription_broadcasts.py
+++ b/src/cringe_pics_telebot/services/subscription_broadcasts.py
@@ -1,0 +1,176 @@
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, time, timedelta
+
+from aiogram import Bot
+
+from cringe_pics_telebot.bot.media import get_message_media_file_id, send_image_to_chat
+from cringe_pics_telebot.repositories import redis as cache
+from cringe_pics_telebot.repositories.postgres import SubscriptionType
+from cringe_pics_telebot.services.random_image import CachedMedia, DownloadedMedia, get_random_image, update_image_cache
+from cringe_pics_telebot.services.subscriptions import get_subscription_types, get_subscription_user_ids
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHECK_INTERVAL = timedelta(seconds=30)
+_DEDUPE_TTL = timedelta(minutes=2)
+
+type TimeProvider = Callable[[], datetime]
+type Sleep = Callable[[float], Awaitable[None]]
+
+
+async def run_subscription_broadcasts(
+    bot: Bot,
+    *,
+    interval: timedelta = DEFAULT_CHECK_INTERVAL,
+    now: TimeProvider | None = None,
+    sleep: Sleep = asyncio.sleep,
+) -> None:
+    now = now or _now
+    _validate_interval(interval)
+    while True:
+        await run_due_subscription_broadcasts(bot, now=now())
+        await sleep(_seconds_until_next_tick(current_time=now(), interval=interval))
+
+
+async def run_due_subscription_broadcasts(bot: Bot, *, now: datetime | None = None) -> int:
+    current_time = now or _now()
+    due_subscription_types = await _due_subscription_types(current_time)
+    if not due_subscription_types:
+        return 0
+
+    sent_counts = await asyncio.gather(
+        *(
+            _broadcast_subscription_type(
+                bot=bot,
+                subscription_type=subscription_type,
+                current_time=current_time,
+            )
+            for subscription_type in due_subscription_types
+        )
+    )
+
+    return sum(sent_counts)
+
+
+async def _due_subscription_types(current_time: datetime) -> list[SubscriptionType]:
+    return [
+        subscription_type
+        for subscription_type in await get_subscription_types()
+        if _same_minute(subscription_type.time, current_time)
+    ]
+
+
+async def _broadcast_subscription_type(*, bot: Bot, subscription_type: SubscriptionType, current_time: datetime) -> int:
+    user_ids = await get_subscription_user_ids(subscription_type.id)
+    if not user_ids:
+        return 0
+
+    reservations = await asyncio.gather(
+        *(
+            _reserve_scheduled_send(
+                subscription_type_id=subscription_type.id,
+                user_id=user_id,
+                current_time=current_time,
+            )
+            for user_id in user_ids
+        )
+    )
+    reserved_user_ids = [user_id for user_id, reserved in zip(user_ids, reservations, strict=True) if reserved]
+
+    if not reserved_user_ids:
+        return 0
+
+    try:
+        image = await get_random_image(subscription_type.id)
+    except Exception:
+        logger.exception("Failed to get image for subscription type %d", subscription_type.id)
+        return 0
+
+    sent_results = await asyncio.gather(
+        *(
+            _send_scheduled_image_to_user(
+                bot=bot,
+                user_id=user_id,
+                subscription_type=subscription_type,
+                image=image,
+            )
+            for user_id in reserved_user_ids
+        )
+    )
+
+    return sum(sent_results)
+
+
+async def _send_scheduled_image_to_user(
+    *,
+    bot: Bot,
+    user_id: int,
+    subscription_type: SubscriptionType,
+    image: DownloadedMedia | CachedMedia,
+) -> int:
+    try:
+        message = await send_image_to_chat(bot=bot, chat_id=user_id, image=image)
+    except Exception:
+        logger.exception(
+            "Failed to send scheduled image for subscription type %d to user %d",
+            subscription_type.id,
+            user_id,
+        )
+        return 0
+
+    try:
+        await update_image_cache(image_path=image.path, image_id=get_message_media_file_id(message))
+    except Exception:
+        logger.exception("Failed to update image %s in cache", image.path)
+
+    return 1
+
+
+async def _reserve_scheduled_send(*, subscription_type_id: int, user_id: int, current_time: datetime) -> bool:
+    return await cache.set_if_absent(
+        key=_dedupe_key(subscription_type_id=subscription_type_id, user_id=user_id, current_time=current_time),
+        value=True,
+        cls=bool,
+        ttl=_DEDUPE_TTL,
+    )
+
+
+def _dedupe_key(*, subscription_type_id: int, user_id: int, current_time: datetime) -> str:
+    minute = _aware_datetime(current_time).astimezone(UTC).strftime("%Y%m%d%H%M")
+    return f"subscription-broadcast:{subscription_type_id}:{user_id}:{minute}"
+
+
+def _same_minute(scheduled_time: time, current_time: datetime) -> bool:
+    if scheduled_time.tzinfo is not None and current_time.tzinfo is not None:
+        current_time = current_time.astimezone(scheduled_time.tzinfo)
+
+    return scheduled_time.hour == current_time.hour and scheduled_time.minute == current_time.minute
+
+
+def _seconds_until_next_tick(*, current_time: datetime, interval: timedelta) -> float:
+    interval_seconds = interval.total_seconds()
+    current_second = current_time.second + current_time.microsecond / 1_000_000
+    seconds_after_boundary = current_second % interval_seconds
+    if seconds_after_boundary == 0:
+        return interval_seconds
+
+    return interval_seconds - seconds_after_boundary
+
+
+def _validate_interval(interval: timedelta) -> None:
+    interval_seconds = interval.total_seconds()
+    if interval_seconds <= 0 or interval_seconds > 60:
+        raise ValueError("Subscription broadcast interval must be between 0 and 60 seconds")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _aware_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+
+    return value

--- a/src/cringe_pics_telebot/services/subscriptions.py
+++ b/src/cringe_pics_telebot/services/subscriptions.py
@@ -1,6 +1,7 @@
 from cringe_pics_telebot.entities.subscriptions import SubscriptionInfo
 from cringe_pics_telebot.repositories.postgres import create_subscription, delete_subscription, transaction
 from cringe_pics_telebot.repositories.postgres import get_subscription_types as get_subscription_types_pg
+from cringe_pics_telebot.repositories.postgres import get_subscription_user_ids as get_subscription_user_ids_from_pg
 from cringe_pics_telebot.repositories.postgres import get_user_subscriptions as get_user_subscriptions_from_pg
 from cringe_pics_telebot.repositories.postgres.entities import CreateSubscription
 from cringe_pics_telebot.repositories.postgres.entities.subscription_type import SubscriptionType
@@ -13,6 +14,10 @@ async def get_subscription_types() -> list[SubscriptionType]:
 
 async def get_user_subscriptions(user_id: int) -> list[SubscriptionInfo]:
     return await get_user_subscriptions_from_pg(user_id)
+
+
+async def get_subscription_user_ids(subscription_type_id: int) -> list[int]:
+    return await get_subscription_user_ids_from_pg(subscription_type_id)
 
 
 async def subscribe(*, user_id: int, subscription_type_id: int) -> None:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -39,6 +39,7 @@ BOT_ENV = {
     **REDIS_ENV,
     "TELEGRAM_BOT_TOKEN": "123456:functional-test-token",
     "YANDEX_DISK_TOKEN": "functional-test-yandex-token",
+    "SUBSCRIPTION_BROADCAST_INTERVAL_SECONDS": "0.5",
 }
 
 logger = logging.getLogger(__name__)
@@ -198,6 +199,24 @@ class FakeYandexServer:
             body = await response.json()
             return body["result"]
 
+    async def wait_for_request(
+        self,
+        method: str,
+        *,
+        predicate: Callable[[dict[str, Any]], bool] | None = None,
+        timeout: float = 10,
+    ) -> dict[str, Any]:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
+            _raise_if_process_exited(self.process, "fake Yandex")
+            for request in await self.requests():
+                if request["method"] == method and (predicate is None or predicate(request)):
+                    return request
+
+            await asyncio.sleep(0.1)
+
+        raise TimeoutError(f"Yandex request {method!r} was not received in {timeout} seconds")
+
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def docker_compose() -> AsyncIterator[DependencyPorts]:
@@ -332,6 +351,44 @@ async def user_subscribed_to_morning(
     seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
 ) -> None:
     await _insert_user_subscription(docker_compose, user_id=42, subscription_type_id=1)
+
+
+@pytest.fixture
+async def reset_functional_state(
+    docker_compose: DependencyPorts,
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+) -> Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]]:
+    async def reset(subscription_types: tuple[FunctionalSubscriptionType, ...]) -> None:
+        _raise_if_process_exited(bot_process, "bot")
+        await fake_telegram_server.reset()
+        await fake_yandex_server.reset()
+        await _reset_database(docker_compose)
+        await _flush_redis(docker_compose)
+        await _insert_subscription_types(docker_compose, subscription_types)
+
+    return reset
+
+
+@pytest.fixture
+async def seed_functional_subscription_types(
+    docker_compose: DependencyPorts,
+) -> Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]]:
+    async def seed(subscription_types: tuple[FunctionalSubscriptionType, ...]) -> None:
+        await _insert_subscription_types(docker_compose, subscription_types)
+
+    return seed
+
+
+@pytest.fixture
+async def create_user_subscription(
+    docker_compose: DependencyPorts,
+) -> Callable[..., Awaitable[None]]:
+    async def create(*, user_id: int, subscription_type_id: int) -> None:
+        await _insert_user_subscription(docker_compose, user_id=user_id, subscription_type_id=subscription_type_id)
+
+    return create
 
 
 def _bot_env(dependency_ports: DependencyPorts) -> dict[str, str]:

--- a/tests/functional/fake_telegram.py
+++ b/tests/functional/fake_telegram.py
@@ -71,6 +71,10 @@ class FakeTelegram:
                 result = await self._get_updates(payload)
             case "sendMessage":
                 result = self._message_from_payload(payload)
+            case "sendPhoto":
+                result = self._sent_media_message_from_payload(payload, media_key="photo")
+            case "sendAnimation":
+                result = self._sent_media_message_from_payload(payload, media_key="animation")
             case "editMessageText" | "editMessageReplyMarkup":
                 result = self._message_from_payload(payload)
             case "answerCallbackQuery":
@@ -143,6 +147,30 @@ class FakeTelegram:
                     "height": 1,
                 }
             ]
+        return message
+
+    def _sent_media_message_from_payload(self, payload: dict[str, Any], *, media_key: str) -> dict[str, Any]:
+        message = self._message_from_payload(payload)
+        media_id = str(payload.get(media_key) or f"functional-{media_key}-file-id")
+
+        if media_key == "animation":
+            message["animation"] = {
+                "file_id": "functional-animation-file-id" if media_id.startswith("attach://") else media_id,
+                "file_unique_id": "functional-animation-file-unique-id",
+                "width": 1,
+                "height": 1,
+                "duration": 1,
+            }
+        else:
+            message["photo"] = [
+                {
+                    "file_id": "functional-photo-file-id" if media_id.startswith("attach://") else media_id,
+                    "file_unique_id": "functional-photo-file-unique-id",
+                    "width": 1,
+                    "height": 1,
+                }
+            ]
+
         return message
 
     async def _read_payload(self, request: web.Request) -> dict[str, Any]:

--- a/tests/functional/fake_yandex.py
+++ b/tests/functional/fake_yandex.py
@@ -29,19 +29,18 @@ class FakeYandex:
         self._requests.append({"method": "resources", "params": params})
 
         directory = params.get("path", "app:/functional").removeprefix("app:/").strip("/")
-        return web.json_response(
-            {
-                "_embedded": {
-                    "items": [
-                        {
-                            "name": "image.png",
-                            "mime_type": "image/png",
-                            "path": f"disk:/Приложения/cringe-pics-telebot/{directory}/image.png",
-                        }
-                    ]
+        if directory == "empty":
+            items: list[dict[str, str]] = []
+        else:
+            items = [
+                {
+                    "name": "image.png",
+                    "mime_type": "image/png",
+                    "path": f"disk:/Приложения/cringe-pics-telebot/{directory}/image.png",
                 }
-            }
-        )
+            ]
+
+        return web.json_response({"_embedded": {"items": items}})
 
     async def download_resource(self, request: web.Request) -> web.Response:
         params = dict(request.query)

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -1,4 +1,7 @@
+import asyncio
 from asyncio import subprocess
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, time
 from typing import Any
 
 import pytest
@@ -9,6 +12,13 @@ from tests.functional.conftest import (
     FakeYandexServer,
     FunctionalSubscriptionType,
 )
+
+
+@pytest.fixture(autouse=True)
+async def reset_state_before_test(
+    reset_functional_state: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+) -> None:
+    await reset_functional_state(())
 
 
 @pytest.mark.parametrize("text", ["/start", "/help", "непонятное сообщение"])
@@ -150,6 +160,73 @@ async def test_bot_sends_image_for_subscription_category(
     assert any(request["method"] == "download" for request in yandex_requests)
 
 
+async def test_bot_sends_scheduled_image_to_subscribed_user_only(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    create_user_subscription: Callable[..., Awaitable[None]],
+) -> None:
+    await seed_functional_subscription_types((_due_subscription_type(1, "/morning", "morning"),))
+    await create_user_subscription(user_id=42, subscription_type_id=1)
+
+    request = await fake_telegram_server.wait_for_request(
+        "sendPhoto",
+        predicate=lambda request: _chat_id(request["payload"]) == 42,
+    )
+    payload = request["payload"]
+    assert _chat_id(payload) == 42
+    assert "photo" in payload
+
+    yandex_requests = await fake_yandex_server.requests()
+    expected_list_request = {
+        "method": "resources",
+        "params": {"path": "app:/morning", "limit": "1000", "offset": "0"},
+    }
+    assert expected_list_request in yandex_requests
+    assert not _telegram_requests_for_chat(await fake_telegram_server.requests(method="sendPhoto"), chat_id=84)
+
+
+async def test_bot_does_not_duplicate_scheduled_send_in_same_minute(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    create_user_subscription: Callable[..., Awaitable[None]],
+) -> None:
+    await seed_functional_subscription_types((_due_subscription_type(1, "/morning", "morning"),))
+    await create_user_subscription(user_id=42, subscription_type_id=1)
+
+    await fake_telegram_server.wait_for_request(
+        "sendPhoto",
+        predicate=lambda request: _chat_id(request["payload"]) == 42,
+    )
+    await _assert_telegram_request_count_stays(
+        fake_telegram_server,
+        method="sendPhoto",
+        predicate=lambda request: _chat_id(request["payload"]) == 42,
+        expected_count=1,
+    )
+
+
+async def test_bot_skips_scheduled_send_when_category_is_empty(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    create_user_subscription: Callable[..., Awaitable[None]],
+) -> None:
+    await seed_functional_subscription_types((_due_subscription_type(1, "/empty", "empty"),))
+    await create_user_subscription(user_id=42, subscription_type_id=1)
+
+    await fake_yandex_server.wait_for_request(
+        "resources",
+        predicate=lambda request: request["params"].get("path") == "app:/empty",
+    )
+
+    assert not _telegram_requests_for_chat(await fake_telegram_server.requests(method="sendPhoto"), chat_id=42)
+    assert bot_process.returncode is None
+
+
 def _is_start_answer(request: dict[str, Any]) -> bool:
     payload = request["payload"]
     return payload.get("chat_id") == 42 and "Приветствую" in payload.get("text", "")
@@ -189,3 +266,47 @@ def _reply_to_message_id(payload: dict[str, Any]) -> int | None:
         return int(payload["reply_parameters"]["message_id"])
 
     return None
+
+
+def _due_subscription_type(subscription_type_id: int, name: str, s3_directory_path: str) -> FunctionalSubscriptionType:
+    return FunctionalSubscriptionType(
+        id=subscription_type_id,
+        name=name,
+        send_time=_current_minute(),
+        s3_directory_path=s3_directory_path,
+    )
+
+
+def _current_minute() -> time:
+    now = datetime.now(UTC)
+    return time(now.hour, now.minute, tzinfo=UTC)
+
+
+def _chat_id(payload: dict[str, Any]) -> int:
+    return int(payload["chat_id"])
+
+
+def _telegram_requests_for_chat(requests: list[dict[str, Any]], *, chat_id: int) -> list[dict[str, Any]]:
+    return [request for request in requests if _chat_id(request["payload"]) == chat_id]
+
+
+async def _assert_telegram_request_count_stays(
+    fake_telegram_server: FakeTelegramServer,
+    *,
+    method: str,
+    predicate: Callable[[dict[str, Any]], bool],
+    expected_count: int,
+    stable_for: float = 1.2,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + stable_for
+    matched_requests: list[dict[str, Any]] = []
+    while asyncio.get_running_loop().time() < deadline:
+        matched_requests = [
+            request for request in await fake_telegram_server.requests(method=method) if predicate(request)
+        ]
+        if len(matched_requests) > expected_count:
+            raise AssertionError(f"Expected {expected_count} {method} requests, got {len(matched_requests)}")
+
+        await asyncio.sleep(0.1)
+
+    assert len(matched_requests) == expected_count


### PR DESCRIPTION
Closes #3

Summary:
- Adds a scheduled subscription broadcast service that checks due category times with minute precision.
- Sends one category media item to subscribed users, with Redis per-user/category/minute dedupe.
- Reuses media sending/cache behavior for downloaded and cached Telegram media.
- Keeps per-user send failures isolated and skips empty categories without crashing.
- Adds functional coverage for scheduled sends, unsubscribed users, duplicate protection, and empty categories.

Validation:
- uv run ruff check
- uv run mypy .
- uv run pytest tests/units -q
- uv run pytest tests/functional -q

Crit:
- Plan review approved.
- Commit review approved after requested changes.