### PR TITLE
Speed up inline query responses

### DIFF
--- a/src/cringe_pics_telebot/repositories/yandex/repo.py
+++ b/src/cringe_pics_telebot/repositories/yandex/repo.py
@@ -1,7 +1,12 @@
+import asyncio
+import logging
 from collections.abc import AsyncGenerator, Iterable
+from typing import cast
 
 from cringe_pics_telebot.repositories.yandex.connection import get_connection
 from cringe_pics_telebot.repositories.yandex.yandex import Image
+
+logger = logging.getLogger(__name__)
 
 
 async def list_dir(dir: str) -> AsyncGenerator[Image]:
@@ -15,6 +20,21 @@ async def download_file(path: str, *, dir: str | None = None) -> bytes:
         return await conn.download_file(path=path, dir=dir)
 
 
-async def get_download_urls(paths: Iterable[str]) -> list[str]:
+async def get_download_urls(paths: Iterable[str]) -> list[str | None]:
+    paths = list(paths)
+    if not paths:
+        return []
+
     async with get_connection() as conn:
-        return [await conn.get_download_url(path) for path in paths]
+        results = await asyncio.gather(
+            *(conn.get_download_url(path) for path in paths),
+            return_exceptions=True,
+        )
+
+    for path, result in zip(paths, results, strict=True):
+        if isinstance(result, asyncio.CancelledError):
+            raise result
+        if isinstance(result, BaseException):
+            logger.error("Failed to get download URL for %s", path, exc_info=result)
+
+    return [None if isinstance(result, BaseException) else cast(str, result) for result in results]

--- a/src/cringe_pics_telebot/services/inline_images.py
+++ b/src/cringe_pics_telebot/services/inline_images.py
@@ -30,7 +30,13 @@ async def get_inline_images(
 
     cached_file_ids = [await cache.get(key=image.path, cls=str) for image in images]
     uncached_images = [image for image, file_id in zip(images, cached_file_ids, strict=True) if file_id is None]
-    download_urls = iter(await get_download_urls(image.path for image in uncached_images) if uncached_images else [])
+    download_urls_by_path = dict(
+        zip(
+            (image.path for image in uncached_images),
+            await get_download_urls(image.path for image in uncached_images) if uncached_images else [],
+            strict=True,
+        )
+    )
 
     results: list[CachedInlineImage | LinkedInlineImage] = []
     for image, file_id in zip(images, cached_file_ids, strict=True):
@@ -44,12 +50,15 @@ async def get_inline_images(
                 )
             )
         else:
+            if (url := download_urls_by_path[image.path]) is None:
+                continue
+
             results.append(
                 LinkedInlineImage(
                     name=image.name,
                     mime_type=image.mime_type,
                     path=image.path,
-                    url=next(download_urls),
+                    url=url,
                 )
             )
 

--- a/src/cringe_pics_telebot/services/inline_images.py
+++ b/src/cringe_pics_telebot/services/inline_images.py
@@ -1,10 +1,15 @@
+import asyncio
+import logging
 from dataclasses import dataclass
+from typing import cast
 
 from cringe_pics_telebot.repositories import redis as cache
 from cringe_pics_telebot.repositories.postgres import SubscriptionType
 from cringe_pics_telebot.repositories.yandex import Image, get_download_urls, list_dir
 
 MAX_INLINE_QUERY_RESULTS = 50
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -28,7 +33,7 @@ async def get_inline_images(
             break
         images.append(image)
 
-    cached_file_ids = [await cache.get(key=image.path, cls=str) for image in images]
+    cached_file_ids = await _get_cached_file_ids(images)
     uncached_images = [image for image, file_id in zip(images, cached_file_ids, strict=True) if file_id is None]
     download_urls_by_path = dict(
         zip(
@@ -63,3 +68,18 @@ async def get_inline_images(
             )
 
     return results
+
+
+async def _get_cached_file_ids(images: list[Image]) -> list[str | None]:
+    results = await asyncio.gather(
+        *(cache.get(key=image.path, cls=str) for image in images),
+        return_exceptions=True,
+    )
+
+    for image, result in zip(images, results, strict=True):
+        if isinstance(result, asyncio.CancelledError):
+            raise result
+        if isinstance(result, BaseException):
+            logger.error("Failed to get cached Telegram file ID for %s", image.path, exc_info=result)
+
+    return [None if isinstance(result, BaseException) else cast(str | None, result) for result in results]

--- a/tests/functional/fake_yandex.py
+++ b/tests/functional/fake_yandex.py
@@ -46,6 +46,9 @@ class FakeYandex:
         params = dict(request.query)
         self._requests.append({"method": "resources/download", "params": params})
 
+        if "broken" in params.get("path", ""):
+            raise web.HTTPServiceUnavailable(text="Functional Yandex failure")
+
         return web.json_response({"href": f"{request.scheme}://{request.host}/download/image.png"})
 
     async def download_file(self, request: web.Request) -> web.Response:

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -212,6 +212,24 @@ async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_p
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
 
 
+async def test_bot_returns_empty_inline_results_when_image_url_fails_and_keeps_polling(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+) -> None:
+    await seed_functional_subscription_types((_due_subscription_type(1, "/broken", "broken"),))
+    await fake_telegram_server.push_inline_query(query="broken", query_id="inline-broken")
+
+    request = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-broken",
+    )
+    assert request["payload"]["results"] == []
+
+    await fake_telegram_server.push_message(text="still running after Yandex failure")
+    await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
+
+
 async def test_bot_sends_scheduled_image_to_subscribed_user_only(
     bot_process: subprocess.Process,
     fake_telegram_server: FakeTelegramServer,

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncGenerator, Iterable
 from datetime import UTC, datetime, time
 
@@ -75,6 +76,77 @@ async def test_get_inline_images_limits_results(monkeypatch: MonkeyPatch) -> Non
     assert results[-1].path == "day/49.png"
 
 
+async def test_get_inline_images_reads_cache_concurrently_and_preserves_storage_order(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    images = [
+        Image(name="first.png", mime_type="image/png", path="day/first.png"),
+        Image(name="second.png", mime_type="image/png", path="day/second.png"),
+        Image(name="third.png", mime_type="image/png", path="day/third.png"),
+    ]
+    cache = _ControlledCache([image.path for image in images])
+
+    async def list_images(directory: str) -> AsyncGenerator[Image]:
+        assert directory == "day"
+        for image in images:
+            yield image
+
+    async def unexpected_urls(paths: Iterable[str]) -> list[str | None]:
+        raise AssertionError(f"Cached images must not request URLs: {list(paths)}")
+
+    monkeypatch.setattr(inline_images, "list_dir", list_images)
+    monkeypatch.setattr(inline_images.cache, "get", cache.get)
+    monkeypatch.setattr(inline_images, "get_download_urls", unexpected_urls)
+
+    images_task = asyncio.create_task(inline_images.get_inline_images(_subscription_type()))
+    await asyncio.wait_for(cache.all_started.wait(), timeout=1)
+    assert not images_task.done()
+
+    for path in reversed([image.path for image in images]):
+        cache.complete(path, file_id=f"telegram-{path}")
+
+    assert await images_task == [
+        CachedInlineImage(
+            name=image.name,
+            mime_type=image.mime_type,
+            path=image.path,
+            file_id=f"telegram-{image.path}",
+        )
+        for image in images
+    ]
+    assert cache.completion_order == list(reversed([image.path for image in images]))
+
+
+async def test_get_inline_images_treats_cache_error_as_miss(monkeypatch: MonkeyPatch) -> None:
+    image = Image(name="fallback.png", mime_type="image/png", path="day/fallback.png")
+
+    async def list_images(directory: str) -> AsyncGenerator[Image]:
+        assert directory == "day"
+        yield image
+
+    async def broken_cache(*, key: str, cls: type[str]) -> None:
+        assert key == image.path
+        assert cls is str
+        raise RuntimeError("Redis unavailable")
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        assert list(paths) == [image.path]
+        return ["https://storage.example/day/fallback.png"]
+
+    monkeypatch.setattr(inline_images, "list_dir", list_images)
+    monkeypatch.setattr(inline_images.cache, "get", broken_cache)
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    assert await inline_images.get_inline_images(_subscription_type()) == [
+        LinkedInlineImage(
+            name=image.name,
+            mime_type=image.mime_type,
+            path=image.path,
+            url="https://storage.example/day/fallback.png",
+        )
+    ]
+
+
 async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: MonkeyPatch) -> None:
     images = [
         Image(name="available.png", mime_type="image/png", path="day/available.png"),
@@ -118,3 +190,27 @@ def _subscription_type() -> SubscriptionType:
         created_at=now,
         updated_at=now,
     )
+
+
+class _ControlledCache:
+    def __init__(self, paths: list[str]) -> None:
+        self._expected_count = len(paths)
+        self._releases = {path: asyncio.Event() for path in paths}
+        self._file_ids: dict[str, str] = {}
+        self._started_count = 0
+        self.all_started = asyncio.Event()
+        self.completion_order: list[str] = []
+
+    async def get(self, *, key: str, cls: type[str]) -> str:
+        assert cls is str
+        self._started_count += 1
+        if self._started_count == self._expected_count:
+            self.all_started.set()
+
+        await self._releases[key].wait()
+        self.completion_order.append(key)
+        return self._file_ids[key]
+
+    def complete(self, path: str, *, file_id: str) -> None:
+        self._file_ids[path] = file_id
+        self._releases[path].set()

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -25,7 +25,7 @@ async def test_get_inline_images_reuses_cached_ids_and_resolves_missing_urls(mon
         assert cls is str
         return "telegram-file-id" if key == "day/cached.png" else None
 
-    async def get_urls(paths: Iterable[str]) -> list[str]:
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
         requested_paths.extend(paths)
         return [f"https://storage.example/{path}" for path in requested_paths]
 
@@ -62,7 +62,7 @@ async def test_get_inline_images_limits_results(monkeypatch: MonkeyPatch) -> Non
         assert key.startswith("day/")
         assert cls is str
 
-    async def get_urls(paths: Iterable[str]) -> list[str]:
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
         return [f"https://storage.example/{path}" for path in paths]
 
     monkeypatch.setattr(inline_images, "list_dir", list_images)
@@ -73,6 +73,39 @@ async def test_get_inline_images_limits_results(monkeypatch: MonkeyPatch) -> Non
 
     assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
     assert results[-1].path == "day/49.png"
+
+
+async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: MonkeyPatch) -> None:
+    images = [
+        Image(name="available.png", mime_type="image/png", path="day/available.png"),
+        Image(name="unavailable.png", mime_type="image/png", path="day/unavailable.png"),
+    ]
+
+    async def list_images(directory: str) -> AsyncGenerator[Image]:
+        assert directory == "day"
+        for image in images:
+            yield image
+
+    async def cache_miss(*, key: str, cls: type[str]) -> None:
+        assert key.startswith("day/")
+        assert cls is str
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        assert list(paths) == ["day/available.png", "day/unavailable.png"]
+        return ["https://storage.example/day/available.png", None]
+
+    monkeypatch.setattr(inline_images, "list_dir", list_images)
+    monkeypatch.setattr(inline_images.cache, "get", cache_miss)
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    assert await inline_images.get_inline_images(_subscription_type()) == [
+        LinkedInlineImage(
+            name="available.png",
+            mime_type="image/png",
+            path="day/available.png",
+            url="https://storage.example/day/available.png",
+        )
+    ]
 
 
 def _subscription_type() -> SubscriptionType:

--- a/tests/units/test_yandex_repo.py
+++ b/tests/units/test_yandex_repo.py
@@ -1,0 +1,89 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from pytest import MonkeyPatch
+
+from cringe_pics_telebot.repositories.yandex import repo
+
+
+async def test_get_download_urls_fetches_concurrently_and_preserves_input_order(monkeypatch: MonkeyPatch) -> None:
+    paths = ["day/first.png", "day/second.png", "day/third.png"]
+    client = _ControlledYandexClient(paths)
+
+    @asynccontextmanager
+    async def get_connection() -> AsyncGenerator[_ControlledYandexClient]:
+        yield client
+
+    monkeypatch.setattr(repo, "get_connection", get_connection)
+
+    urls_task = asyncio.create_task(repo.get_download_urls(paths))
+    await asyncio.wait_for(client.all_started.wait(), timeout=1)
+    assert not urls_task.done()
+
+    for path in reversed(paths):
+        client.complete(path)
+
+    assert await urls_task == [f"https://storage.example/{path}" for path in paths]
+    assert client.completion_order == list(reversed(paths))
+
+
+async def test_get_download_urls_returns_none_for_failed_lookup_after_batch_finishes(monkeypatch: MonkeyPatch) -> None:
+    paths = ["day/good.png", "day/broken.png"]
+    client = _ControlledYandexClient(paths, broken_path="day/broken.png")
+
+    @asynccontextmanager
+    async def get_connection() -> AsyncGenerator[_ControlledYandexClient]:
+        yield client
+
+    monkeypatch.setattr(repo, "get_connection", get_connection)
+
+    urls_task = asyncio.create_task(repo.get_download_urls(paths))
+    await asyncio.wait_for(client.all_started.wait(), timeout=1)
+    client.complete("day/broken.png")
+    await asyncio.wait_for(client.completed("day/broken.png"), timeout=1)
+    assert not urls_task.done()
+
+    client.complete("day/good.png")
+    assert await urls_task == ["https://storage.example/day/good.png", None]
+
+
+async def test_get_download_urls_skips_connection_for_empty_input(monkeypatch: MonkeyPatch) -> None:
+    @asynccontextmanager
+    async def unexpected_connection() -> AsyncGenerator[None]:
+        raise AssertionError("Empty input must not open a Yandex connection")
+        yield
+
+    monkeypatch.setattr(repo, "get_connection", unexpected_connection)
+
+    assert await repo.get_download_urls([]) == []
+
+
+class _ControlledYandexClient:
+    def __init__(self, paths: list[str], *, broken_path: str | None = None) -> None:
+        self._expected_count = len(paths)
+        self._releases = {path: asyncio.Event() for path in paths}
+        self._completions = {path: asyncio.Event() for path in paths}
+        self._broken_path = broken_path
+        self._started_count = 0
+        self.all_started = asyncio.Event()
+        self.completion_order: list[str] = []
+
+    async def get_download_url(self, path: str) -> str:
+        self._started_count += 1
+        if self._started_count == self._expected_count:
+            self.all_started.set()
+
+        await self._releases[path].wait()
+        self.completion_order.append(path)
+        self._completions[path].set()
+        if path == self._broken_path:
+            raise RuntimeError(f"Failed to get URL for {path}")
+
+        return f"https://storage.example/{path}"
+
+    def complete(self, path: str) -> None:
+        self._releases[path].set()
+
+    async def completed(self, path: str) -> None:
+        await self._completions[path].wait()


### PR DESCRIPTION
Closes #15

## Summary
- fetch Redis media cache entries concurrently while preserving storage order
- fetch Yandex Disk temporary URLs concurrently on the shared client session
- degrade Redis lookup failures to URL fallbacks and skip only media whose Yandex URL lookup fails
- preserve task cancellation and keep polling alive after per-media external failures
- add deterministic event/barrier concurrency tests without timing assertions

## Performance
Deterministic local harness with 10 cache misses and 5 ms simulated latency per Redis/Yandex operation, five runs:

- before: 113.72 ms median
- after: 11.56 ms median
- improvement: approximately 9.8x faster (89.8% lower latency)

The benchmark is documented here rather than committed as a timing-sensitive CI test.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run pytest tests/units -q` (9 passed)
- `uv run pytest tests/functional -q` (19 passed)

## Review
- implementation plan approved in Crit
- both implementation commits approved in Crit
- combined branch diff approved in Crit
- one first-round comment led to partial-success handling for Yandex URL failures