### PR TITLE
Добавить fuzzy-поиск и рандомизацию inline-результатов

### DIFF
--- a/src/cringe_pics_telebot/bot/inline.py
+++ b/src/cringe_pics_telebot/bot/inline.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import logging
 
@@ -12,7 +13,12 @@ from aiogram.types import (
 )
 
 from cringe_pics_telebot.repositories.postgres import SubscriptionType
-from cringe_pics_telebot.services.inline_images import CachedInlineImage, LinkedInlineImage, get_inline_images
+from cringe_pics_telebot.services.inline_images import (
+    MAX_INLINE_QUERY_RESULTS,
+    CachedInlineImage,
+    LinkedInlineImage,
+    get_inline_images,
+)
 from cringe_pics_telebot.services.subscriptions import get_subscription_types
 
 logger = logging.getLogger(__name__)
@@ -22,42 +28,60 @@ router = Router(name="inline")
 
 @router.inline_query()
 async def answer_inline_query(inline_query: InlineQuery) -> None:
-    subscription_type = await _find_subscription_type(inline_query.query)
-    if subscription_type is None:
+    subscription_types = await _find_subscription_types(inline_query.query)
+    if not subscription_types:
         await inline_query.answer([], cache_time=0, is_personal=True)
         return
 
     try:
-        images = await get_inline_images(subscription_type)
-        results = [_inline_result(image, subscription_type=subscription_type) for image in images]
+        results = await _get_inline_results(subscription_types)
     except Exception:
         logger.exception(
-            "Failed to prepare inline results for user %d and category %s",
+            "Failed to prepare inline results for user %d and categories %s",
             inline_query.from_user.id,
-            subscription_type.name,
+            ", ".join(subscription_type.name for subscription_type in subscription_types),
         )
         results = []
 
-    await inline_query.answer(results, cache_time=0, is_personal=True)
+    await inline_query.answer(results[:MAX_INLINE_QUERY_RESULTS], cache_time=0, is_personal=True)
 
 
-async def _find_subscription_type(query: str) -> SubscriptionType | None:
+async def _find_subscription_types(query: str) -> list[SubscriptionType]:
+    if not _normalize_category(query):
+        return []
+
+    return [
+        subscription_type
+        for subscription_type in await get_subscription_types()
+        if category_matches_query(query, subscription_type.name)
+    ]
+
+
+def category_matches_query(query: str, category: str) -> bool:
     normalized_query = _normalize_category(query)
-    if not normalized_query:
-        return None
-
-    return next(
-        (
-            subscription_type
-            for subscription_type in await get_subscription_types()
-            if _normalize_category(subscription_type.name) == normalized_query
-        ),
-        None,
-    )
+    return bool(normalized_query) and normalized_query in _normalize_category(category)
 
 
 def _normalize_category(category: str) -> str:
     return category.strip().removeprefix("/").casefold()
+
+
+async def _get_inline_results(subscription_types: list[SubscriptionType]) -> list[InlineQueryResultUnion]:
+    images_by_subscription_type = await asyncio.gather(
+        *(get_inline_images(subscription_type) for subscription_type in subscription_types)
+    )
+    seen_paths: set[str] = set()
+    results: list[InlineQueryResultUnion] = []
+
+    for subscription_type, images in zip(subscription_types, images_by_subscription_type, strict=True):
+        for image in images:
+            if image.path in seen_paths:
+                continue
+
+            seen_paths.add(image.path)
+            results.append(_inline_result(image, subscription_type=subscription_type))
+
+    return results
 
 
 def _inline_result(

--- a/src/cringe_pics_telebot/bot/inline.py
+++ b/src/cringe_pics_telebot/bot/inline.py
@@ -1,6 +1,8 @@
 import asyncio
 import hashlib
 import logging
+import random
+from collections.abc import Callable
 
 from aiogram import Router
 from aiogram.types import (
@@ -34,7 +36,7 @@ async def answer_inline_query(inline_query: InlineQuery) -> None:
         return
 
     try:
-        results = await _get_inline_results(subscription_types)
+        results = _shuffle_inline_results(await _get_inline_results(subscription_types))
     except Exception:
         logger.exception(
             "Failed to prepare inline results for user %d and categories %s",
@@ -82,6 +84,16 @@ async def _get_inline_results(subscription_types: list[SubscriptionType]) -> lis
             results.append(_inline_result(image, subscription_type=subscription_type))
 
     return results
+
+
+def _shuffle_inline_results(
+    results: list[InlineQueryResultUnion],
+    *,
+    shuffler: Callable[[list[InlineQueryResultUnion]], None] | None = None,
+) -> list[InlineQueryResultUnion]:
+    shuffled_results = results.copy()
+    (shuffler or random.shuffle)(shuffled_results)
+    return shuffled_results
 
 
 def _inline_result(

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -160,13 +160,13 @@ async def test_bot_sends_image_for_subscription_category(
     assert any(request["method"] == "download" for request in yandex_requests)
 
 
-async def test_bot_returns_day_images_for_inline_query(
+async def test_bot_returns_day_images_for_partial_inline_query(
     bot_process: subprocess.Process,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
     seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
 ) -> None:
-    await fake_telegram_server.push_inline_query(query="  DAY ")
+    await fake_telegram_server.push_inline_query(query="  dA ")
 
     request = await fake_telegram_server.wait_for_request("answerInlineQuery")
 

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime, time
+from typing import cast
 
 import pytest
+from aiogram.types import InlineQuery, InlineQueryResultPhoto, InlineQueryResultUnion
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.bot import inline
@@ -87,6 +89,65 @@ async def test_get_inline_results_combines_categories_without_duplicate_paths(mo
     assert len({payload["id"] for payload in payloads}) == 3
 
 
+def test_shuffle_inline_results_uses_injected_shuffler_on_a_copy() -> None:
+    results = _inline_results(3)
+    shuffled_inputs: list[list[str]] = []
+
+    def reverse(items: list[InlineQueryResultUnion]) -> None:
+        shuffled_inputs.append([item.id for item in items])
+        items.reverse()
+
+    shuffled_results = inline._shuffle_inline_results(results, shuffler=reverse)
+
+    assert shuffled_inputs == [["result-0", "result-1", "result-2"]]
+    assert [result.id for result in shuffled_results] == ["result-2", "result-1", "result-0"]
+    assert [result.id for result in results] == ["result-0", "result-1", "result-2"]
+
+
+async def test_answer_inline_query_shuffles_before_limit_and_disables_telegram_cache(monkeypatch: MonkeyPatch) -> None:
+    subscription_type = _subscription_type(2, "/day", "day")
+    results = _inline_results(inline.MAX_INLINE_QUERY_RESULTS + 1)
+    query = _FakeInlineQuery(query="day")
+
+    async def find_subscription_types(query: str) -> list[SubscriptionType]:
+        assert query == "day"
+        return [subscription_type]
+
+    async def get_inline_results(subscription_types: list[SubscriptionType]) -> list[InlineQueryResultUnion]:
+        assert subscription_types == [subscription_type]
+        return results
+
+    def reverse(items: list[InlineQueryResultUnion]) -> None:
+        items.reverse()
+
+    monkeypatch.setattr(inline, "_find_subscription_types", find_subscription_types)
+    monkeypatch.setattr(inline, "_get_inline_results", get_inline_results)
+    monkeypatch.setattr(inline.random, "shuffle", reverse)
+
+    await inline.answer_inline_query(cast(InlineQuery, query))
+
+    assert len(query.results) == inline.MAX_INLINE_QUERY_RESULTS
+    assert [result.id for result in query.results] == [
+        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS, 0, -1)
+    ]
+    assert query.cache_time == 0
+    assert query.is_personal is True
+    assert [result.id for result in results] == [
+        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 1)
+    ]
+
+
+def _inline_results(count: int) -> list[InlineQueryResultUnion]:
+    return [
+        InlineQueryResultPhoto(
+            id=f"result-{index}",
+            photo_url=f"https://storage.example/{index}.png",
+            thumbnail_url=f"https://storage.example/{index}.png",
+        )
+        for index in range(count)
+    ]
+
+
 def _subscription_type(subscription_type_id: int, name: str, directory: str) -> SubscriptionType:
     now = datetime.now(UTC)
     return SubscriptionType(
@@ -97,3 +158,27 @@ def _subscription_type(subscription_type_id: int, name: str, directory: str) -> 
         created_at=now,
         updated_at=now,
     )
+
+
+class _FakeInlineQuery:
+    def __init__(self, *, query: str) -> None:
+        self.query = query
+        self.from_user = _FakeUser()
+        self.results: list[InlineQueryResultUnion] = []
+        self.cache_time: int | None = None
+        self.is_personal: bool | None = None
+
+    async def answer(
+        self,
+        results: list[InlineQueryResultUnion],
+        *,
+        cache_time: int,
+        is_personal: bool,
+    ) -> None:
+        self.results = results
+        self.cache_time = cache_time
+        self.is_personal = is_personal
+
+
+class _FakeUser:
+    id = 42

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -1,0 +1,99 @@
+from datetime import UTC, datetime, time
+
+import pytest
+from pytest import MonkeyPatch
+
+from cringe_pics_telebot.bot import inline
+from cringe_pics_telebot.repositories.postgres import SubscriptionType
+from cringe_pics_telebot.services.inline_images import CachedInlineImage, LinkedInlineImage
+
+
+@pytest.mark.parametrize(
+    ("query", "category", "matches"),
+    [
+        ("day", "/day", True),
+        ("  DA ", "/day", True),
+        ("/d", "/day", True),
+        ("ING", "/evening", True),
+        ("", "/day", False),
+        (" / ", "/day", False),
+        ("night", "/day", False),
+    ],
+)
+def test_category_matches_query(query: str, category: str, matches: bool) -> None:
+    assert inline.category_matches_query(query, category) is matches
+
+
+async def test_find_subscription_types_returns_every_matching_category(monkeypatch: MonkeyPatch) -> None:
+    subscription_types = [
+        _subscription_type(1, "/morning", "morning"),
+        _subscription_type(2, "/day", "day"),
+        _subscription_type(3, "/evening", "evening"),
+        _subscription_type(4, "/night", "night"),
+    ]
+
+    async def get_subscription_types() -> list[SubscriptionType]:
+        return subscription_types
+
+    monkeypatch.setattr(inline, "get_subscription_types", get_subscription_types)
+
+    assert await inline._find_subscription_types("  ING ") == [subscription_types[0], subscription_types[2]]
+
+
+async def test_get_inline_results_combines_categories_without_duplicate_paths(monkeypatch: MonkeyPatch) -> None:
+    morning = _subscription_type(1, "/morning", "morning")
+    evening = _subscription_type(3, "/evening", "evening")
+
+    async def get_inline_images(subscription_type: SubscriptionType) -> list[CachedInlineImage | LinkedInlineImage]:
+        if subscription_type == morning:
+            return [
+                CachedInlineImage(
+                    name="shared.png",
+                    mime_type="image/png",
+                    path="shared/image.png",
+                    file_id="telegram-shared",
+                ),
+                LinkedInlineImage(
+                    name="morning.png",
+                    mime_type="image/png",
+                    path="morning/image.png",
+                    url="https://storage.example/morning.png",
+                ),
+            ]
+
+        return [
+            LinkedInlineImage(
+                name="duplicate.png",
+                mime_type="image/png",
+                path="shared/image.png",
+                url="https://storage.example/duplicate.png",
+            ),
+            LinkedInlineImage(
+                name="evening.png",
+                mime_type="image/png",
+                path="evening/image.png",
+                url="https://storage.example/evening.png",
+            ),
+        ]
+
+    monkeypatch.setattr(inline, "get_inline_images", get_inline_images)
+
+    results = await inline._get_inline_results([morning, evening])
+    payloads = [result.model_dump(exclude_none=True) for result in results]
+
+    assert [payload["title"] for payload in payloads] == ["shared.png", "morning.png", "evening.png"]
+    assert payloads[0]["description"] == "Категория /morning"
+    assert payloads[2]["description"] == "Категория /evening"
+    assert len({payload["id"] for payload in payloads}) == 3
+
+
+def _subscription_type(subscription_type_id: int, name: str, directory: str) -> SubscriptionType:
+    now = datetime.now(UTC)
+    return SubscriptionType(
+        id=subscription_type_id,
+        name=name,
+        time=time(13, 0, tzinfo=UTC),
+        s3_directory_path=directory,
+        created_at=now,
+        updated_at=now,
+    )


### PR DESCRIPTION
Closes #16

## Что сделано

- добавлено регистронезависимое частичное сопоставление нормализованного inline query с несколькими категориями;
- результаты совпавших категорий загружаются конкурентно, объединяются и дедуплицируются по storage path;
- полный набор кандидатов перемешивается перед общим Telegram-лимитом в 50 результатов;
- сохранены пустой fallback и параметры answerInlineQuery cache_time=0, is_personal=true;
- добавлены unit-тесты fuzzy matching, multi-category deduplication и детерминированной рандомизации, а functional-тест обновлён для частичного mixed-case запроса.

## Проверка

- uv run ruff check .
- uv run ruff format --check .
- uv run mypy .
- uv run pytest tests/units -q — 20 passed
- uv run pytest tests/functional -q — 19 passed

## Crit

План, каждый из двух implementation-коммитов и итоговый diff ветки одобрены без замечаний.