### PR TITLE
Показывать время до отправки админ-рассылки

### DIFF
--- a/src/cringe_pics_telebot/bot/admin.py
+++ b/src/cringe_pics_telebot/bot/admin.py
@@ -28,9 +28,11 @@ from cringe_pics_telebot.services.admin_broadcast_schedules import (
     AdminBroadcastSchedule,
     InvalidAdminBroadcastScheduleError,
     PastAdminBroadcastScheduleError,
+    format_admin_broadcast_countdown,
     format_admin_broadcast_schedule,
     parse_admin_broadcast_schedule,
 )
+from cringe_pics_telebot.services.timezones import get_user_timezone_offset
 
 from .admin_access import IsAdministrator
 from .admin_callback_data import AdminAction, AdminCallbackData
@@ -84,6 +86,7 @@ async def handle_admin_callback(callback: CallbackQuery, state: FSMContext) -> N
             callback_data=callback_data,
             message=message,
             state=state,
+            viewer_user_id=callback.from_user.id,
         )
     except Exception:
         logger.exception("Failed to process admin callback %s", callback.data)
@@ -208,6 +211,7 @@ async def _dispatch_admin_callback(
     callback_data: AdminCallbackData,
     message: Message,
     state: FSMContext,
+    viewer_user_id: int,
 ) -> str | None:
     match callback_data.action:
         case AdminAction.panel:
@@ -223,7 +227,11 @@ async def _dispatch_admin_callback(
             await _start_new_broadcast(message=message, state=state)
         case AdminAction.edit_broadcast:
             await state.clear()
-            return await _show_broadcast(message, callback_data.broadcast_id)
+            return await _show_broadcast(
+                message,
+                callback_data.broadcast_id,
+                viewer_user_id=viewer_user_id,
+            )
         case AdminAction.edit_message:
             return await _start_edit_message(message, state, callback_data.broadcast_id)
         case AdminAction.edit_schedule:
@@ -269,14 +277,24 @@ async def _start_new_broadcast(*, message: Message, state: FSMContext) -> None:
     )
 
 
-async def _show_broadcast(message: Message, broadcast_id: int) -> str | None:
+async def _show_broadcast(
+    message: Message,
+    broadcast_id: int,
+    *,
+    viewer_user_id: int,
+) -> str | None:
     broadcast = await _editable_broadcast(broadcast_id)
     if broadcast is None:
         await _edit_current_broadcast_list(message)
         return "Рассылка уже начала отправляться или недоступна."
     recipient_ids = await get_admin_broadcast_recipient_ids(broadcast.id)
+    viewer_timezone_offset_minutes = await get_user_timezone_offset(viewer_user_id)
     await message.edit_text(
-        _broadcast_details(broadcast, extra_recipient_count=len(recipient_ids)),
+        _broadcast_details(
+            broadcast,
+            extra_recipient_count=len(recipient_ids),
+            viewer_timezone_offset_minutes=viewer_timezone_offset_minutes,
+        ),
         reply_markup=create_admin_broadcast_keyboard(broadcast.id),
     )
     return None
@@ -444,11 +462,23 @@ async def _state_broadcast_id(state: FSMContext) -> int | None:
     return broadcast_id
 
 
-def _broadcast_details(broadcast: AdminBroadcast, *, extra_recipient_count: int) -> str:
+def _broadcast_details(
+    broadcast: AdminBroadcast,
+    *,
+    extra_recipient_count: int,
+    viewer_timezone_offset_minutes: int,
+) -> str:
+    countdown_label = "До отправки для вас" if broadcast.timezone_offset_minutes is None else "До отправки"
+    countdown = format_admin_broadcast_countdown(
+        broadcast.scheduled_local_at,
+        broadcast.timezone_offset_minutes,
+        viewer_timezone_offset_minutes=viewer_timezone_offset_minutes,
+    )
     return (
         f"<b>Рассылка #{broadcast.id}</b>\n\n"
         "Дата и время: "
         f"<b>{format_admin_broadcast_schedule(broadcast.scheduled_local_at, broadcast.timezone_offset_minutes)}</b>\n"
+        f"{countdown_label}: <b>{countdown}</b>\n"
         f"Исходное сообщение: <code>{broadcast.source_chat_id}/{broadcast.source_message_id}</code>\n"
         f"Дополнительных получателей: <b>{extra_recipient_count}</b>"
     )

--- a/src/cringe_pics_telebot/services/admin_broadcast_schedules.py
+++ b/src/cringe_pics_telebot/services/admin_broadcast_schedules.py
@@ -76,3 +76,67 @@ def format_admin_broadcast_schedule(
     if timezone_offset_minutes is None:
         return f"{formatted} · локально" if short else f"{formatted} — локальное время каждого получателя"
     return f"{formatted} · UTC{format_timezone_offset(timezone_offset_minutes)}"
+
+
+def format_admin_broadcast_countdown(
+    local_at: datetime,
+    timezone_offset_minutes: int | None,
+    *,
+    viewer_timezone_offset_minutes: int,
+    now: datetime | None = None,
+) -> str:
+    effective_offset_minutes = (
+        viewer_timezone_offset_minutes if timezone_offset_minutes is None else timezone_offset_minutes
+    )
+    scheduled_at = local_at.replace(
+        tzinfo=timezone(timedelta(minutes=effective_offset_minutes)),
+    )
+    remaining_seconds = max(
+        0,
+        int((scheduled_at - aware_datetime(now or datetime.now(UTC))).total_seconds()),
+    )
+
+    if remaining_seconds >= 24 * 60 * 60:
+        days, remainder = divmod(remaining_seconds, 24 * 60 * 60)
+        hours, remainder = divmod(remainder, 60 * 60)
+        minutes = remainder // 60
+        return " ".join(
+            (
+                _format_duration_part(days, "день", "дня", "дней"),
+                _format_duration_part(hours, "час", "часа", "часов"),
+                _format_duration_part(minutes, "минута", "минуты", "минут"),
+            )
+        )
+
+    if remaining_seconds >= 60 * 60:
+        hours, remainder = divmod(remaining_seconds, 60 * 60)
+        minutes = remainder // 60
+        return " ".join(
+            (
+                _format_duration_part(hours, "час", "часа", "часов"),
+                _format_duration_part(minutes, "минута", "минуты", "минут"),
+            )
+        )
+
+    minutes, seconds = divmod(remaining_seconds, 60)
+    return " ".join(
+        (
+            _format_duration_part(minutes, "минута", "минуты", "минут"),
+            _format_duration_part(seconds, "секунда", "секунды", "секунд"),
+        )
+    )
+
+
+def _format_duration_part(value: int, singular: str, paucal: str, plural: str) -> str:
+    remainder = value % 100
+    if 11 <= remainder <= 14:
+        word = plural
+    else:
+        match value % 10:
+            case 1:
+                word = singular
+            case 2 | 3 | 4:
+                word = paucal
+            case _:
+                word = plural
+    return f"{value} {word}"

--- a/tests/functional/test_admin_panel.py
+++ b/tests/functional/test_admin_panel.py
@@ -162,6 +162,15 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
     ]
 
     await fake_telegram_server.push_callback_query(
+        data=_admin_callback(AdminAction.edit_broadcast, broadcast_id),
+    )
+    broadcast_details = await fake_telegram_server.wait_for_request(
+        "editMessageText",
+        predicate=lambda request: "Рассылка #" in request["payload"].get("text", ""),
+    )
+    assert "До отправки для вас: <b>" in broadcast_details["payload"]["text"]
+
+    await fake_telegram_server.push_callback_query(
         data=_admin_callback(AdminAction.edit_schedule, broadcast_id),
         message_id=101,
     )

--- a/tests/units/test_admin_broadcast_schedules.py
+++ b/tests/units/test_admin_broadcast_schedules.py
@@ -5,6 +5,7 @@ import pytest
 from cringe_pics_telebot.services.admin_broadcast_schedules import (
     InvalidAdminBroadcastScheduleError,
     PastAdminBroadcastScheduleError,
+    format_admin_broadcast_countdown,
     format_admin_broadcast_schedule,
     parse_admin_broadcast_schedule,
 )
@@ -59,3 +60,75 @@ def test_reject_schedule_that_passed_in_latest_timezone() -> None:
             "17.08.2026 09:59",
             now=datetime(2026, 8, 17, 22, 0, tzinfo=UTC),
         )
+
+
+@pytest.mark.parametrize(
+    ("local_at", "timezone_offset_minutes", "viewer_timezone_offset_minutes", "now", "expected"),
+    [
+        (
+            datetime(2026, 8, 19, 13, 23),
+            240,
+            -300,
+            datetime(2026, 8, 17, 3, 0, tzinfo=UTC),
+            "2 дня 6 часов 23 минуты",
+        ),
+        (
+            datetime(2026, 8, 18, 3, 0),
+            0,
+            420,
+            datetime(2026, 8, 17, 3, 0, tzinfo=UTC),
+            "1 день 0 часов 0 минут",
+        ),
+        (
+            datetime(2026, 8, 17, 6, 5),
+            0,
+            420,
+            datetime(2026, 8, 17, 3, 0, tzinfo=UTC),
+            "3 часа 5 минут",
+        ),
+        (
+            datetime(2026, 8, 17, 4, 0),
+            0,
+            420,
+            datetime(2026, 8, 17, 3, 0, tzinfo=UTC),
+            "1 час 0 минут",
+        ),
+        (
+            datetime(2026, 8, 17, 3, 59, 7),
+            0,
+            420,
+            datetime(2026, 8, 17, 3, 0, tzinfo=UTC),
+            "59 минут 7 секунд",
+        ),
+        (
+            datetime(2026, 8, 17, 3, 0),
+            0,
+            420,
+            datetime(2026, 8, 17, 3, 1, tzinfo=UTC),
+            "0 минут 0 секунд",
+        ),
+        (
+            datetime(2026, 8, 17, 10, 0),
+            None,
+            420,
+            datetime(2026, 8, 17, 2, 30, tzinfo=UTC),
+            "30 минут 0 секунд",
+        ),
+    ],
+)
+def test_format_admin_broadcast_countdown(
+    local_at: datetime,
+    timezone_offset_minutes: int | None,
+    viewer_timezone_offset_minutes: int,
+    now: datetime,
+    expected: str,
+) -> None:
+    assert (
+        format_admin_broadcast_countdown(
+            local_at,
+            timezone_offset_minutes,
+            viewer_timezone_offset_minutes=viewer_timezone_offset_minutes,
+            now=now,
+        )
+        == expected
+    )


### PR DESCRIPTION
## Что изменено

- в карточке запланированной рассылки добавлен обратный отсчёт до отправки;
- интервалы от суток показываются как дни, часы и минуты, интервалы от часа до суток — как часы и минуты, интервалы менее часа — как минуты и секунды;
- для локальной рассылки отсчёт считается в часовом поясе просматривающего администратора, а для расписания с UTC-смещением — до общего момента отправки;
- добавлены русские формы единиц времени и защита от отрицательного отсчёта.

## Проверки

- `UV_CACHE_DIR=/tmp/cringe-pics-telebot-uv-cache uv run ruff check`
- `UV_CACHE_DIR=/tmp/cringe-pics-telebot-uv-cache uv run ruff format --check`
- `UV_CACHE_DIR=/tmp/cringe-pics-telebot-uv-cache uv run mypy .`
- `UV_CACHE_DIR=/tmp/cringe-pics-telebot-uv-cache uv run pytest tests/units -q` — 79 passed
- `UV_CACHE_DIR=/tmp/cringe-pics-telebot-uv-cache uv run pytest tests/functional -q` — 32 passed

## Ревью

- план реализации одобрен Crit;
- implementation-коммит одобрен Crit без замечаний.
