### PR TITLE
Добавить метрики задержки inline-режима

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd cringe-pics-telebot
 
 ### 2. Настроить переменные окружения
 
-Создайте четыре файла. Они игнорируются Git и не должны попадать в репозиторий.
+Создайте четыре обязательных файла. Они игнорируются Git и не должны попадать в репозиторий.
 
 `docker/bot/.env`:
 
@@ -81,6 +81,20 @@ REDIS_HOST=redis
 ```dotenv
 YANDEX_DISK_TOKEN=<OAuth-токен Яндекс Диска>
 ```
+
+Чтобы отправлять метрики на существующий внешний Graphite/StatsD, скопируйте пример и укажите доступный из bot container адрес StatsD:
+
+```bash
+cp docker/statsd/.env.example docker/statsd/.env
+```
+
+```dotenv
+STATSD_HOST=statsd.example.com
+STATSD_PORT=8125
+STATSD_PREFIX=cringe_pics_telebot
+```
+
+StatsD использует UDP. Проект не запускает Graphite и не управляет его хранилищем или dashboard; на внешнем сервере и в firewall должен быть разрешён UDP-трафик от bot host к указанному порту. Если `docker/statsd/.env` отсутствует, метрики отключены. Если endpoint настроен, но port некорректен или адрес не разрешается, бот завершает startup с явной ошибкой конфигурации. Ошибка UDP-отправки после успешного запуска не останавливает polling.
 
 Дополнительно в `docker/bot/.env` можно задать:
 

--- a/compose.yml
+++ b/compose.yml
@@ -39,6 +39,8 @@ services:
       - ./docker/postgres/.env
       - ./docker/redis/.env
       - ./docker/yandex/.env
+      - path: ./docker/statsd/.env
+        required: false
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/statsd/.env.example
+++ b/docker/statsd/.env.example
@@ -1,0 +1,3 @@
+STATSD_HOST=statsd.example.com
+STATSD_PORT=8125
+STATSD_PREFIX=cringe_pics_telebot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "redis[hiredis]>=8.1.0",
   "serpyco-rs>=1.21.0",
   "sqlalchemy[asyncio]>=2.1.0b3",
+  "statsd>=4.0.1",
 ]
 
 [project.scripts]
@@ -44,4 +45,8 @@ dev = [
 
 [[tool.mypy.overrides]]
 module = "asyncpg"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "statsd"
 ignore_missing_imports = true

--- a/src/cringe_pics_telebot/bot/inline.py
+++ b/src/cringe_pics_telebot/bot/inline.py
@@ -19,6 +19,14 @@ from cringe_pics_telebot.services.inline_images import (
     MAX_INLINE_QUERY_RESULTS,
     get_inline_images,
 )
+from cringe_pics_telebot.services.inline_metrics import (
+    CATEGORIES_LOOKUP_STAGE,
+    RESULTS_PREPARE_STAGE,
+    TELEGRAM_ANSWER_STAGE,
+    InlineQueryMetrics,
+    get_inline_query_metrics,
+    inline_query_stage,
+)
 from cringe_pics_telebot.services.random_image import CachedMedia, LinkedMedia
 from cringe_pics_telebot.services.subscriptions import get_subscription_types
 
@@ -35,29 +43,40 @@ router = Router(name="inline")
 
 @router.inline_query()
 async def answer_inline_query(inline_query: InlineQuery) -> None:
-    subscription_types = await _find_subscription_types(inline_query.query)
-    if not subscription_types:
-        await inline_query.answer([], cache_time=0, is_personal=True)
-        return
+    with InlineQueryMetrics.start(
+        query_is_empty=not bool(normalize_category_search_term(inline_query.query)),
+    ) as metrics:
+        subscription_types = await _find_subscription_types(inline_query.query)
+        metrics.counts.matched_categories = len(subscription_types)
 
-    try:
-        results = _prepare_inline_results(await _get_inline_results(subscription_types))
-    except Exception:
-        logger.exception(
-            "Failed to prepare inline results for user %d and categories %s",
-            inline_query.from_user.id,
-            ", ".join(subscription_type.name for subscription_type in subscription_types),
-        )
-        results = []
+        if not subscription_types:
+            await _answer_inline_query(inline_query, [])
+            return
 
-    answer_results: list[InlineQueryResultUnion] = [*results[:MAX_INLINE_QUERY_RESULTS]]
-    await inline_query.answer(answer_results, cache_time=0, is_personal=True)
+        try:
+            raw_results = await _get_inline_results(subscription_types)
+            metrics.counts.results_prepared = len(raw_results)
+            results = _prepare_inline_results(raw_results)
+        except Exception:
+            metrics.set_outcome("handled_error")
+            logger.exception("Failed to prepare inline results; correlation_id=%s", metrics.correlation_id)
+            results = []
+
+        if metrics.counts.url_failures and metrics.outcome == "success":
+            metrics.set_outcome("partial_error")
+        answer_results: list[InlineQueryResultUnion] = [*results[:MAX_INLINE_QUERY_RESULTS]]
+        metrics.counts.results_sent = len(answer_results)
+        await _answer_inline_query(inline_query, answer_results)
 
 
+@inline_query_stage(CATEGORIES_LOOKUP_STAGE)
 async def _find_subscription_types(query: str) -> list[SubscriptionType]:
     if not normalize_category_search_term(query):
         return []
 
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.postgres_calls += 1
     return [
         subscription_type
         for subscription_type in await get_subscription_types()
@@ -83,10 +102,18 @@ def category_matches_query(query: str, category: str, search_aliases: Sequence[s
 
 
 async def _get_inline_results(subscription_types: list[SubscriptionType]) -> list[InlineMediaResult]:
+    images = await get_inline_images(subscription_types, limit_per_category=None)
+    return _build_inline_results(images)
+
+
+@inline_query_stage(RESULTS_PREPARE_STAGE)
+def _build_inline_results(
+    images: list[tuple[SubscriptionType, CachedMedia | LinkedMedia]],
+) -> list[InlineMediaResult]:
     seen_paths: set[str] = set()
     results: list[InlineMediaResult] = []
 
-    for subscription_type, image in await get_inline_images(subscription_types, limit_per_category=None):
+    for subscription_type, image in images:
         if image.path in seen_paths:
             continue
 
@@ -96,6 +123,18 @@ async def _get_inline_results(subscription_types: list[SubscriptionType]) -> lis
     return results
 
 
+@inline_query_stage(TELEGRAM_ANSWER_STAGE)
+async def _answer_inline_query(
+    inline_query: InlineQuery,
+    results: list[InlineQueryResultUnion],
+) -> None:
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.telegram_calls += 1
+    await inline_query.answer(results, cache_time=0, is_personal=True)
+
+
+@inline_query_stage(RESULTS_PREPARE_STAGE)
 def _prepare_inline_results(
     results: list[InlineMediaResult],
     *,

--- a/src/cringe_pics_telebot/bot/polling.py
+++ b/src/cringe_pics_telebot/bot/polling.py
@@ -6,6 +6,7 @@ from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from datetime import timedelta
 
 from cringe_pics_telebot.bot.bot import create_bot, dp
+from cringe_pics_telebot.helpers.metrics import configured_metrics
 from cringe_pics_telebot.repositories.postgres import connect as connect_postgres
 from cringe_pics_telebot.repositories.redis import connect as connect_redis
 from cringe_pics_telebot.repositories.yandex import connect as connect_yandex
@@ -72,6 +73,7 @@ async def _connect_redis() -> AsyncGenerator:
 async def start_polling() -> None:
     connectors = (_connect_postgres, _create_yandex_client, _connect_redis)
     async with AsyncExitStack() as stack:
+        stack.enter_context(configured_metrics())
         for connector in connectors:
             await stack.enter_async_context(connector())
 

--- a/src/cringe_pics_telebot/helpers/metrics.py
+++ b/src/cringe_pics_telebot/helpers/metrics.py
@@ -1,0 +1,160 @@
+import logging
+import os
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Protocol, Self
+
+from statsd import StatsClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATSD_PORT = 8125
+DEFAULT_STATSD_PREFIX = "cringe_pics_telebot"
+
+type Clock = Callable[[], float]
+
+
+@dataclass(frozen=True, slots=True)
+class TimingMetric:
+    name: str
+    milliseconds: float
+
+
+@dataclass(frozen=True, slots=True)
+class CounterMetric:
+    name: str
+    value: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class GaugeMetric:
+    name: str
+    value: int | float
+
+
+type Metric = TimingMetric | CounterMetric | GaugeMetric
+
+
+class MetricsSink(Protocol):
+    def emit(self, metrics: Iterable[Metric]) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _StatsDPipeline(Protocol):
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None: ...
+
+    def timing(self, stat: str, delta: float) -> None: ...
+
+    def incr(self, stat: str, count: int = 1) -> None: ...
+
+    def gauge(self, stat: str, value: int | float) -> None: ...
+
+
+class _StatsDClient(Protocol):
+    def pipeline(self) -> _StatsDPipeline: ...
+
+    def close(self) -> None: ...
+
+
+class NullMetricsSink:
+    def emit(self, metrics: Iterable[Metric]) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class StatsDMetricsSink:
+    def __init__(self, client: _StatsDClient) -> None:
+        self._client = client
+
+    def emit(self, metrics: Iterable[Metric]) -> None:
+        try:
+            with self._client.pipeline() as pipeline:
+                for metric in metrics:
+                    match metric:
+                        case TimingMetric():
+                            pipeline.timing(metric.name, metric.milliseconds)
+                        case CounterMetric():
+                            pipeline.incr(metric.name, metric.value)
+                        case GaugeMetric():
+                            pipeline.gauge(metric.name, metric.value)
+        except Exception:
+            logger.exception("Failed to emit StatsD metrics")
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:
+            logger.exception("Failed to close StatsD client")
+
+
+@dataclass(slots=True)
+class Stopwatch:
+    _clock: Clock
+    _started_at: float
+
+    @classmethod
+    def start(cls, *, clock: Clock = time.monotonic) -> Stopwatch:
+        return cls(_clock=clock, _started_at=clock())
+
+    def elapsed_milliseconds(self) -> float:
+        return (self._clock() - self._started_at) * 1_000
+
+
+_metrics_sink: MetricsSink = NullMetricsSink()
+
+
+def get_metrics_sink() -> MetricsSink:
+    return _metrics_sink
+
+
+def create_metrics_sink(
+    environ: Mapping[str, str] | None = None,
+    *,
+    client_factory: Callable[..., _StatsDClient] = StatsClient,
+) -> MetricsSink:
+    environ = os.environ if environ is None else environ
+    host = environ.get("STATSD_HOST", "").strip()
+    if not host:
+        logger.info("StatsD metrics are disabled because STATSD_HOST is not set")
+        return NullMetricsSink()
+
+    port = int(environ.get("STATSD_PORT", str(DEFAULT_STATSD_PORT)))
+    if not 1 <= port <= 65_535:
+        raise ValueError("STATSD_PORT is outside the range 1..65535")
+
+    prefix = environ.get("STATSD_PREFIX", DEFAULT_STATSD_PREFIX).strip() or None
+    client = client_factory(host=host, port=port, prefix=prefix)
+
+    logger.info("StatsD metrics are enabled for %s:%d with prefix %s", host, port, prefix or "<none>")
+    return StatsDMetricsSink(client)
+
+
+@contextmanager
+def configured_metrics(
+    environ: Mapping[str, str] | None = None,
+    *,
+    client_factory: Callable[..., _StatsDClient] = StatsClient,
+) -> Iterator[MetricsSink]:
+    global _metrics_sink
+
+    previous_sink = _metrics_sink
+    sink = create_metrics_sink(environ, client_factory=client_factory)
+    _metrics_sink = sink
+    try:
+        yield sink
+    finally:
+        _metrics_sink = previous_sink
+        sink.close()

--- a/src/cringe_pics_telebot/services/inline_images.py
+++ b/src/cringe_pics_telebot/services/inline_images.py
@@ -8,6 +8,14 @@ from cringe_pics_telebot.repositories.postgres import (
 from cringe_pics_telebot.repositories.yandex import get_download_urls
 from cringe_pics_telebot.services.random_image import CachedMedia, LinkedMedia
 
+from .inline_metrics import (
+    MEDIA_CATALOG_STAGE,
+    MEDIA_URLS_STAGE,
+    RESULTS_PREPARE_STAGE,
+    get_inline_query_metrics,
+    inline_query_stage,
+)
+
 MAX_INLINE_QUERY_RESULTS = 50
 
 
@@ -16,7 +24,11 @@ async def get_inline_images(
     *,
     limit_per_category: int | None = MAX_INLINE_QUERY_RESULTS,
 ) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
-    media = await get_category_media_by_subscription_types([item.id for item in subscription_types])
+    media = await _get_catalog_media([item.id for item in subscription_types])
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.catalog_media = len(media)
+
     media_by_category: dict[int, list[CategoryMedia]] = {}
     for item in media:
         category_media = media_by_category.setdefault(item.subscription_type_id, [])
@@ -32,14 +44,49 @@ async def get_inline_images(
                 selected_media.append(item)
 
     pending_paths = list(dict.fromkeys(item.source_path for item in selected_media if item.telegram_file_id is None))
-    download_urls_by_path = dict(
-        zip(
-            pending_paths,
-            await get_download_urls(pending_paths) if pending_paths else [],
-            strict=True,
-        )
+    if metrics is not None:
+        metrics.counts.selected_media = len(selected_media)
+        metrics.counts.ready_media = len(selected_media) - len(pending_paths)
+        metrics.counts.pending_media = len(pending_paths)
+
+    if pending_paths:
+        download_urls = await _get_media_urls(pending_paths)
+        if metrics is not None:
+            metrics.counts.url_successes += sum(url is not None for url in download_urls)
+            metrics.counts.url_failures += sum(url is None for url in download_urls)
+    else:
+        download_urls = []
+    download_urls_by_path = dict(zip(pending_paths, download_urls, strict=True))
+    return _prepare_inline_image_results(
+        selected_media,
+        subscription_types=subscription_types,
+        download_urls_by_path=download_urls_by_path,
     )
 
+
+@inline_query_stage(MEDIA_CATALOG_STAGE)
+async def _get_catalog_media(subscription_type_ids: list[int]) -> list[CategoryMedia]:
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.postgres_calls += 1
+    return await get_category_media_by_subscription_types(subscription_type_ids)
+
+
+@inline_query_stage(MEDIA_URLS_STAGE)
+async def _get_media_urls(paths: list[str]) -> list[str | None]:
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.yandex_calls += len(paths)
+    return await get_download_urls(paths)
+
+
+@inline_query_stage(RESULTS_PREPARE_STAGE)
+def _prepare_inline_image_results(
+    selected_media: list[CategoryMedia],
+    *,
+    subscription_types: Sequence[SubscriptionType],
+    download_urls_by_path: dict[str, str | None],
+) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
     subscription_types_by_id = {item.id: item for item in subscription_types}
     results: list[tuple[SubscriptionType, CachedMedia | LinkedMedia]] = []
     for item in selected_media:

--- a/src/cringe_pics_telebot/services/inline_metrics.py
+++ b/src/cringe_pics_telebot/services/inline_metrics.py
@@ -1,0 +1,254 @@
+import asyncio
+import inspect
+import json
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass, field
+from functools import wraps
+from typing import Any, cast
+
+from cringe_pics_telebot.helpers.metrics import (
+    Clock,
+    CounterMetric,
+    Metric,
+    MetricsSink,
+    TimingMetric,
+    get_metrics_sink,
+)
+
+logger = logging.getLogger(__name__)
+
+CATEGORIES_LOOKUP_STAGE = "categories.lookup"
+MEDIA_CATALOG_STAGE = "media.catalog"
+MEDIA_URLS_STAGE = "media.urls"
+RESULTS_PREPARE_STAGE = "results.prepare"
+TELEGRAM_ANSWER_STAGE = "telegram.answer"
+
+
+@dataclass(slots=True)
+class InlineQueryCounts:
+    matched_categories: int = 0
+    catalog_media: int = 0
+    selected_media: int = 0
+    ready_media: int = 0
+    pending_media: int = 0
+    url_successes: int = 0
+    url_failures: int = 0
+    results_prepared: int = 0
+    results_sent: int = 0
+    postgres_calls: int = 0
+    yandex_calls: int = 0
+    redis_calls: int = 0
+    telegram_calls: int = 0
+    retries: int = 0
+
+
+@dataclass(slots=True)
+class InlineQueryMetrics:
+    correlation_id: str
+    query_is_empty: bool
+    counts: InlineQueryCounts
+    _sink: MetricsSink
+    _clock: Clock
+    _started_at: float
+    _outcome: str = "success"
+    _stage_durations_ms: dict[str, float] = field(default_factory=dict)
+    _finished: bool = False
+
+    @classmethod
+    @contextmanager
+    def start(
+        cls,
+        *,
+        query_is_empty: bool,
+        sink: MetricsSink | None = None,
+        clock: Clock = time.monotonic,
+        correlation_id: str | None = None,
+    ) -> Iterator[InlineQueryMetrics]:
+        metrics = cls(
+            correlation_id=correlation_id or uuid.uuid4().hex,
+            query_is_empty=query_is_empty,
+            counts=InlineQueryCounts(),
+            _sink=sink or get_metrics_sink(),
+            _clock=clock,
+            _started_at=clock(),
+        )
+        try:
+            with _current_inline_metrics.set(metrics):
+                try:
+                    yield metrics
+                except asyncio.CancelledError:
+                    metrics.set_outcome("cancelled")
+                    raise
+                except Exception:
+                    metrics.set_outcome("unhandled_error")
+                    raise
+        finally:
+            metrics.finish()
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        started_at = self._clock()
+        try:
+            yield
+        finally:
+            elapsed_ms = (self._clock() - started_at) * 1_000
+            self._stage_durations_ms[name] = self._stage_durations_ms.get(name, 0) + elapsed_ms
+
+    def set_outcome(self, outcome: str) -> None:
+        self._outcome = outcome
+
+    @property
+    def outcome(self) -> str:
+        return self._outcome
+
+    def finish(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+
+        total_ms = (self._clock() - self._started_at) * 1_000
+        scenario = self.scenario
+        category_set = self.category_set
+        catalog_size = self.catalog_size
+        durations_ms = {"total": total_ms, **self._stage_durations_ms}
+        self._sink.emit(
+            self._metrics(
+                total_ms=total_ms,
+                scenario=scenario,
+                category_set=category_set,
+                catalog_size=catalog_size,
+            )
+        )
+        logger.info(
+            json.dumps(
+                {
+                    "event": "inline_query_metrics",
+                    "correlation_id": self.correlation_id,
+                    "outcome": self._outcome,
+                    "scenario": scenario,
+                    "category_set": category_set,
+                    "catalog_size": catalog_size,
+                    "durations_ms": {name: round(value, 3) for name, value in durations_ms.items()},
+                    "counts": asdict(self.counts),
+                },
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+
+    @property
+    def scenario(self) -> str:
+        if self.query_is_empty:
+            return "empty_query"
+        if self.counts.matched_categories == 0:
+            return "unknown_category"
+        if self.counts.catalog_media == 0:
+            return "known_empty"
+        if self.counts.ready_media and self.counts.pending_media:
+            return "mixed"
+        if self.counts.pending_media:
+            return "pending_only"
+        return "catalog_only"
+
+    @property
+    def category_set(self) -> str:
+        if self.counts.matched_categories == 0:
+            return "none"
+        if self.counts.matched_categories == 1:
+            return "single"
+        return "multiple"
+
+    @property
+    def catalog_size(self) -> str:
+        if self.counts.catalog_media == 0:
+            return "empty"
+        if self.counts.catalog_media <= 50:
+            return "small"
+        return "large"
+
+    def _metrics(
+        self,
+        *,
+        total_ms: float,
+        scenario: str,
+        category_set: str,
+        catalog_size: str,
+    ) -> list[Metric]:
+        metrics: list[Metric] = [
+            CounterMetric("inline.requests"),
+            CounterMetric(f"inline.outcomes.{self._outcome}.requests"),
+            CounterMetric(f"inline.scenarios.{scenario}.requests"),
+            CounterMetric(f"inline.category_sets.{category_set}.requests"),
+            CounterMetric(f"inline.catalog_sizes.{catalog_size}.requests"),
+            TimingMetric("inline.total", total_ms),
+            TimingMetric(f"inline.outcomes.{self._outcome}.total", total_ms),
+            TimingMetric(f"inline.scenarios.{scenario}.total", total_ms),
+            TimingMetric(f"inline.category_sets.{category_set}.total", total_ms),
+            TimingMetric(f"inline.catalog_sizes.{catalog_size}.total", total_ms),
+        ]
+        metrics.extend(
+            TimingMetric(f"inline.stages.{name}", milliseconds)
+            for name, milliseconds in self._stage_durations_ms.items()
+        )
+        metrics.extend(
+            [
+                CounterMetric("inline.media.catalog_items", self.counts.catalog_media),
+                CounterMetric("inline.media.selected_items", self.counts.selected_media),
+                CounterMetric("inline.media.ready_items", self.counts.ready_media),
+                CounterMetric("inline.media.pending_items", self.counts.pending_media),
+                CounterMetric("inline.media.url_successes", self.counts.url_successes),
+                CounterMetric("inline.media.url_failures", self.counts.url_failures),
+                CounterMetric("inline.results.prepared", self.counts.results_prepared),
+                CounterMetric("inline.results.sent", self.counts.results_sent),
+                CounterMetric("inline.dependencies.postgres.calls", self.counts.postgres_calls),
+                CounterMetric("inline.dependencies.yandex.calls", self.counts.yandex_calls),
+                CounterMetric("inline.dependencies.redis.calls", self.counts.redis_calls),
+                CounterMetric("inline.dependencies.telegram.calls", self.counts.telegram_calls),
+                CounterMetric("inline.retries", self.counts.retries),
+            ]
+        )
+        return metrics
+
+
+_current_inline_metrics: ContextVar[InlineQueryMetrics | None] = ContextVar(
+    "current_inline_metrics",
+    default=None,
+)
+
+
+def get_inline_query_metrics() -> InlineQueryMetrics | None:
+    return _current_inline_metrics.get()
+
+
+def inline_query_stage[**P, R](name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def decorate(function: Callable[P, R]) -> Callable[P, R]:
+        if inspect.iscoroutinefunction(function):
+            async_function = cast(Callable[P, Awaitable[Any]], function)
+
+            @wraps(function)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+                metrics = get_inline_query_metrics()
+                if metrics is None:
+                    return await async_function(*args, **kwargs)
+                with metrics.stage(name):
+                    return await async_function(*args, **kwargs)
+
+            return cast(Callable[P, R], async_wrapper)
+
+        @wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            metrics = get_inline_query_metrics()
+            if metrics is None:
+                return function(*args, **kwargs)
+            with metrics.stage(name):
+                return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorate

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -294,6 +294,43 @@ class FakeYandexServer:
         raise TimeoutError(f"Yandex request {method!r} was not received in {timeout} seconds")
 
 
+@dataclass(slots=True)
+class FakeStatsDServer:
+    base_url: str
+    udp_host: str
+    udp_port: int
+    process: subprocess.Process
+
+    async def reset(self) -> None:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(f"{self.base_url}/test/reset") as response,
+        ):
+            response.raise_for_status()
+
+    async def metrics(self, *, name: str | None = None) -> list[dict[str, Any]]:
+        params = {"name": name} if name is not None else None
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(f"{self.base_url}/test/metrics", params=params) as response,
+        ):
+            response.raise_for_status()
+            body = await response.json()
+            return body["result"]
+
+    async def wait_for_metric(self, name: str, *, timeout: float = 10) -> dict[str, Any]:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(
+                f"{self.base_url}/test/wait",
+                params={"name": name, "timeout": timeout},
+            ) as response,
+        ):
+            response.raise_for_status()
+            body = await response.json()
+            return body["result"]
+
+
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def docker_compose() -> AsyncIterator[DependencyPorts]:
     dependency_ports = DependencyPorts(postgres=_get_unused_tcp_port(), redis=_get_unused_tcp_port())
@@ -434,14 +471,47 @@ async def fake_yandex_server() -> AsyncIterator[FakeYandexServer]:
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def fake_statsd_server() -> AsyncIterator[FakeStatsDServer]:
+    http_port = _get_unused_tcp_port()
+    udp_port = _get_unused_udp_port()
+    process = await subprocess.create_subprocess_exec(
+        sys.executable,
+        str(FUNCTIONAL_DIR / "fake_statsd.py"),
+        "--http-port",
+        str(http_port),
+        "--udp-port",
+        str(udp_port),
+        cwd=ROOT_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    server = FakeStatsDServer(
+        base_url=f"http://127.0.0.1:{http_port}",
+        udp_host="127.0.0.1",
+        udp_port=udp_port,
+        process=process,
+    )
+    await _wait_until_ready(lambda: _http_ready(f"{server.base_url}/healthz"), "fake StatsD")
+
+    try:
+        yield server
+    finally:
+        await _terminate_process(process)
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def bot_process(
     docker_compose: DependencyPorts,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
 ) -> AsyncIterator[subprocess.Process]:
     env = _bot_env(docker_compose)
     env["TELEGRAM_API_BASE_URL"] = fake_telegram_server.base_url
     env["YANDEX_DISK_API_BASE_URL"] = f"{fake_yandex_server.base_url}/v1/disk/"
+    env["STATSD_HOST"] = fake_statsd_server.udp_host
+    env["STATSD_PORT"] = str(fake_statsd_server.udp_port)
+    env["STATSD_PREFIX"] = "functional"
 
     process = await subprocess.create_subprocess_exec(
         "uv",
@@ -465,10 +535,12 @@ async def seeded_subscription_types(
     bot_process: subprocess.Process,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
 ) -> tuple[FunctionalSubscriptionType, ...]:
     _raise_if_process_exited(bot_process, "bot")
     await fake_telegram_server.reset()
     await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
     await _reset_database(docker_compose)
     await _flush_redis(docker_compose)
     await _insert_subscription_types(docker_compose, SEEDED_SUBSCRIPTION_TYPES)
@@ -500,10 +572,12 @@ async def reset_dependency_state(
     docker_compose: DependencyPorts,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
 ) -> Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]]:
     async def reset(subscription_types: tuple[FunctionalSubscriptionType, ...]) -> None:
         await fake_telegram_server.reset()
         await fake_yandex_server.reset()
+        await fake_statsd_server.reset()
         await _reset_database(docker_compose)
         await _flush_redis(docker_compose)
         await _insert_subscription_types(docker_compose, subscription_types)
@@ -1228,6 +1302,12 @@ def _raise_if_process_exited(process: subprocess.Process, name: str) -> None:
 
 def _get_unused_tcp_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _get_unused_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
 

--- a/tests/functional/fake_statsd.py
+++ b/tests/functional/fake_statsd.py
@@ -1,0 +1,102 @@
+import argparse
+import asyncio
+from typing import Any
+
+from aiohttp import web
+
+
+class FakeStatsD(asyncio.DatagramProtocol):
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self._metrics: list[dict[str, Any]] = []
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        asyncio.create_task(self._record_datagram(data, addr))
+
+    async def _record_datagram(self, data: bytes, addr: tuple[str, int]) -> None:
+        metrics = [_parse_metric(line, addr) for line in data.decode("ascii").splitlines() if line]
+        async with self._condition:
+            self._metrics.extend(metrics)
+            self._condition.notify_all()
+
+    async def healthcheck(self, request: web.Request) -> web.Response:
+        return web.json_response({"ok": True})
+
+    async def list_metrics(self, request: web.Request) -> web.Response:
+        name = request.query.get("name")
+        async with self._condition:
+            metrics = self._metrics
+            if name is not None:
+                metrics = [metric for metric in metrics if metric["name"] == name]
+            return web.json_response({"ok": True, "result": metrics})
+
+    async def wait_for_metric(self, request: web.Request) -> web.Response:
+        name = request.query["name"]
+        timeout = float(request.query.get("timeout", "10"))
+        try:
+            async with asyncio.timeout(timeout):
+                async with self._condition:
+                    while not (metrics := [metric for metric in self._metrics if metric["name"] == name]):
+                        await self._condition.wait()
+        except TimeoutError as error:
+            raise web.HTTPRequestTimeout(text=f"Metric {name!r} was not received") from error
+        return web.json_response({"ok": True, "result": metrics[0]})
+
+    async def reset(self, request: web.Request) -> web.Response:
+        async with self._condition:
+            self._metrics.clear()
+            self._condition.notify_all()
+        return web.json_response({"ok": True})
+
+
+def _parse_metric(line: str, addr: tuple[str, int]) -> dict[str, Any]:
+    name, payload = line.split(":", maxsplit=1)
+    value, metric_type, *_ = payload.split("|")
+    parsed_value = int(value) if metric_type == "c" else float(value)
+    return {
+        "name": name,
+        "value": parsed_value,
+        "type": metric_type,
+        "source": {"host": addr[0], "port": addr[1]},
+    }
+
+
+def create_app(fake: FakeStatsD) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/healthz", fake.healthcheck)
+    app.router.add_get("/test/metrics", fake.list_metrics)
+    app.router.add_get("/test/wait", fake.wait_for_metric)
+    app.router.add_post("/test/reset", fake.reset)
+    return app
+
+
+async def serve(*, host: str, http_port: int, udp_port: int) -> None:
+    fake = FakeStatsD()
+    loop = asyncio.get_running_loop()
+    transport, _ = await loop.create_datagram_endpoint(lambda: fake, local_addr=(host, udp_port))
+    runner = web.AppRunner(create_app(fake))
+    await runner.setup()
+    site = web.TCPSite(runner, host=host, port=http_port)
+    await site.start()
+    try:
+        await asyncio.Event().wait()
+    finally:
+        transport.close()
+        await runner.cleanup()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--http-port", type=int, required=True)
+    parser.add_argument("--udp-port", type=int, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(serve(host=args.host, http_port=args.http_port, udp_port=args.udp_port))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -8,6 +8,7 @@ import pytest
 from cringe_pics_telebot.bot.subscription_callback_data import SubscriptionCallbackData
 from cringe_pics_telebot.services.media_sync import MediaSyncSummary
 from tests.functional.conftest import (
+    FakeStatsDServer,
     FakeTelegramServer,
     FakeYandexServer,
     FunctionalSubscriptionType,
@@ -257,6 +258,7 @@ async def test_bot_recovers_invalid_catalog_file_id_once(
 @pytest.mark.parametrize("query", ["  dA ", "  ДНЕ "])
 async def test_bot_returns_day_images_for_partial_inline_query(
     bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
     seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
@@ -300,9 +302,33 @@ async def test_bot_returns_day_images_for_partial_inline_query(
     } in yandex_requests
     assert not any(request["method"] == "download" for request in yandex_requests)
 
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.pending_only.total",
+        "functional.inline.stages.categories.lookup",
+        "functional.inline.stages.media.catalog",
+        "functional.inline.stages.media.urls",
+        "functional.inline.stages.results.prepare",
+        "functional.inline.stages.telegram.answer",
+        "functional.inline.dependencies.postgres.calls",
+        "functional.inline.dependencies.yandex.calls",
+        "functional.inline.dependencies.redis.calls",
+        "functional.inline.dependencies.telegram.calls",
+        "functional.inline.media.catalog_items",
+        "functional.inline.results.sent",
+    )
+    assert all(metrics[name]["type"] == "ms" for name in metrics if ".total" in name or ".stages." in name)
+    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 2
+    assert metrics["functional.inline.dependencies.redis.calls"]["value"] == 0
+    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
+    assert metrics["functional.inline.media.catalog_items"]["value"] == 2
+    assert metrics["functional.inline.results.sent"]["value"] == 2
+
 
 async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_polling(
     bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
     seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
 ) -> None:
@@ -314,12 +340,52 @@ async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_p
     )
     assert request["payload"]["results"] == []
 
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.unknown_category.total",
+        "functional.inline.dependencies.postgres.calls",
+        "functional.inline.dependencies.yandex.calls",
+        "functional.inline.dependencies.redis.calls",
+        "functional.inline.dependencies.telegram.calls",
+    )
+    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 1
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+    assert metrics["functional.inline.dependencies.redis.calls"]["value"] == 0
+    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
+    assert not await fake_statsd_server.metrics(name="functional.inline.stages.media.catalog")
+
     await fake_telegram_server.push_message(text="still running")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
 
 
+async def test_bot_records_empty_inline_query_without_database_lookup(
+    bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
+    fake_telegram_server: FakeTelegramServer,
+) -> None:
+    await fake_telegram_server.push_inline_query(query=" / ", query_id="inline-blank")
+
+    request = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-blank",
+    )
+    assert request["payload"]["results"] == []
+
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.empty_query.total",
+        "functional.inline.dependencies.postgres.calls",
+        "functional.inline.dependencies.yandex.calls",
+        "functional.inline.dependencies.telegram.calls",
+    )
+    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 0
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
+
+
 async def test_bot_returns_empty_inline_results_for_known_empty_category_and_keeps_polling(
     bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
     seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
     synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
@@ -336,12 +402,24 @@ async def test_bot_returns_empty_inline_results_for_known_empty_category_and_kee
     )
     assert request["payload"]["results"] == []
 
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.known_empty.total",
+        "functional.inline.stages.media.catalog",
+        "functional.inline.dependencies.postgres.calls",
+        "functional.inline.dependencies.yandex.calls",
+    )
+    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+    assert not await fake_statsd_server.metrics(name="functional.inline.stages.media.urls")
+
     await fake_telegram_server.push_message(text="still running after empty inline category")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
 
 
 async def test_bot_returns_empty_inline_results_when_image_url_fails_and_keeps_polling(
     bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
     seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
     synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
@@ -358,12 +436,23 @@ async def test_bot_returns_empty_inline_results_when_image_url_fails_and_keeps_p
     )
     assert request["payload"]["results"] == []
 
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.outcomes.partial_error.total",
+        "functional.inline.scenarios.pending_only.total",
+        "functional.inline.media.url_failures",
+        "functional.inline.results.sent",
+    )
+    assert metrics["functional.inline.media.url_failures"]["value"] == 1
+    assert metrics["functional.inline.results.sent"]["value"] == 0
+
     await fake_telegram_server.push_message(text="still running after Yandex failure")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
 
 
 async def test_inline_uses_persisted_file_id_after_ordinary_delivery(
     bot_process: subprocess.Process,
+    fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,
     seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
@@ -390,6 +479,133 @@ async def test_inline_uses_persisted_file_id_after_ordinary_delivery(
     assert result["photo_file_id"] == "functional-photo-file-id"
     assert "photo_url" not in result
     assert not await fake_yandex_server.requests()
+
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.catalog_only.total",
+        "functional.inline.media.ready_items",
+        "functional.inline.media.pending_items",
+        "functional.inline.dependencies.yandex.calls",
+    )
+    assert metrics["functional.inline.media.ready_items"]["value"] == 1
+    assert metrics["functional.inline.media.pending_items"]["value"] == 0
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+
+
+async def test_inline_metrics_cover_mixed_ready_and_pending_media(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
+    seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+) -> None:
+    await fake_yandex_server.configure_directory(
+        "day",
+        images=[{"name": "first.png"}, {"name": "second.png"}],
+    )
+    await synchronize_functional_media_catalog()
+    await fake_yandex_server.reset()
+
+    await fake_telegram_server.push_message(text="/day")
+    await fake_telegram_server.wait_for_request("editMessageMedia")
+
+    await fake_telegram_server.reset()
+    await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
+    await fake_telegram_server.push_inline_query(query="day", query_id="inline-mixed")
+    answer = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-mixed",
+    )
+
+    assert len(answer["payload"]["results"]) == 2
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.scenarios.mixed.total",
+        "functional.inline.media.ready_items",
+        "functional.inline.media.pending_items",
+        "functional.inline.dependencies.yandex.calls",
+    )
+    assert metrics["functional.inline.media.ready_items"]["value"] == 1
+    assert metrics["functional.inline.media.pending_items"]["value"] == 1
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 1
+
+
+async def test_inline_metrics_cover_multiple_categories(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+) -> None:
+    subscription_types = (
+        FunctionalSubscriptionType(1, "/first", time(0), "first", ("shared",)),
+        FunctionalSubscriptionType(2, "/second", time(0), "second", ("shared",)),
+    )
+    await seed_functional_subscription_types(subscription_types)
+    await fake_yandex_server.configure_directory("first", images=[{"name": "first.png"}])
+    await fake_yandex_server.configure_directory("second", images=[{"name": "second.png"}])
+    await synchronize_functional_media_catalog()
+    await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
+
+    await fake_telegram_server.push_inline_query(query="shared", query_id="inline-multiple")
+    answer = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-multiple",
+    )
+
+    assert len(answer["payload"]["results"]) == 2
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.category_sets.multiple.total",
+        "functional.inline.dependencies.postgres.calls",
+        "functional.inline.dependencies.yandex.calls",
+        "functional.inline.media.catalog_items",
+    )
+    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 2
+    assert metrics["functional.inline.media.catalog_items"]["value"] == 2
+
+
+async def test_inline_metrics_cover_large_catalog_and_telegram_limit(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+) -> None:
+    await seed_functional_subscription_types((FunctionalSubscriptionType(1, "/large", time(0), "large"),))
+    await fake_yandex_server.configure_directory(
+        "large",
+        images=[{"name": f"image-{index}.png"} for index in range(60)],
+    )
+    await synchronize_functional_media_catalog()
+    await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
+
+    await fake_telegram_server.push_inline_query(query="large", query_id="inline-large")
+    answer = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-large",
+    )
+
+    assert len(answer["payload"]["results"]) == 50
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.catalog_sizes.large.total",
+        "functional.inline.media.catalog_items",
+        "functional.inline.dependencies.yandex.calls",
+        "functional.inline.results.prepared",
+        "functional.inline.results.sent",
+    )
+    assert metrics["functional.inline.media.catalog_items"]["value"] == 60
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 60
+    assert metrics["functional.inline.results.prepared"]["value"] == 60
+    assert metrics["functional.inline.results.sent"]["value"] == 50
 
 
 async def test_inline_excludes_media_deactivated_by_later_sync(
@@ -424,6 +640,13 @@ async def test_inline_excludes_media_deactivated_by_later_sync(
 def _is_start_answer(request: dict[str, Any]) -> bool:
     payload = request["payload"]
     return payload.get("chat_id") == 42 and "Что умеет бот" in payload.get("text", "")
+
+
+async def _wait_for_metrics(
+    fake_statsd_server: FakeStatsDServer,
+    *names: str,
+) -> dict[str, dict[str, Any]]:
+    return {name: await fake_statsd_server.wait_for_metric(name) for name in names}
 
 
 def _is_subscription_list_answer(request: dict[str, Any]) -> bool:

--- a/tests/functional/test_inline_latency_baseline.py
+++ b/tests/functional/test_inline_latency_baseline.py
@@ -1,0 +1,241 @@
+import json
+import math
+import os
+import statistics
+from asyncio import subprocess
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import time
+from functools import partial
+from typing import Any
+
+import pytest
+
+from cringe_pics_telebot.services.media_sync import MediaSyncSummary
+from tests.functional.conftest import (
+    FakeStatsDServer,
+    FakeTelegramServer,
+    FakeYandexServer,
+    FunctionalSubscriptionType,
+)
+
+RUNS_PER_SCENARIO = 20
+COMMON_STAGES = (
+    "categories.lookup",
+    "media.catalog",
+    "results.prepare",
+    "telegram.answer",
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_INLINE_LATENCY_BASELINE") != "1",
+    reason="set RUN_INLINE_LATENCY_BASELINE=1 to collect the non-gating latency baseline",
+)
+
+
+async def test_collect_inline_latency_baseline(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
+    reset_dependency_state: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+) -> None:
+    scenarios: dict[str, dict[str, Any]] = {}
+
+    await _prepare_catalog(
+        reset_dependency_state=reset_dependency_state,
+        fake_yandex_server=fake_yandex_server,
+        synchronize_media_catalog=synchronize_functional_media_catalog,
+        subscription_types=(FunctionalSubscriptionType(1, "/small", time(0), "small"),),
+        directories={"small": [{"name": "first.png"}, {"name": "second.png"}]},
+    )
+    scenarios["small_pending"] = await _measure_scenario(
+        query="small",
+        expected_results=2,
+        expected_counts={
+            "dependencies.postgres.calls": 2,
+            "dependencies.yandex.calls": 2,
+            "dependencies.redis.calls": 0,
+            "dependencies.telegram.calls": 1,
+            "media.catalog_items": 2,
+            "results.sent": 2,
+        },
+        stages=(*COMMON_STAGES, "media.urls"),
+        fake_telegram_server=fake_telegram_server,
+        fake_statsd_server=fake_statsd_server,
+    )
+
+    await _prepare_catalog(
+        reset_dependency_state=reset_dependency_state,
+        fake_yandex_server=fake_yandex_server,
+        synchronize_media_catalog=synchronize_functional_media_catalog,
+        subscription_types=(FunctionalSubscriptionType(1, "/warm", time(0), "warm"),),
+        directories={"warm": [{"name": "only.png"}]},
+    )
+    await fake_telegram_server.push_message(text="/warm")
+    await fake_telegram_server.wait_for_request("editMessageMedia")
+    scenarios["small_catalog_only"] = await _measure_scenario(
+        query="warm",
+        expected_results=1,
+        expected_counts={
+            "dependencies.postgres.calls": 2,
+            "dependencies.yandex.calls": 0,
+            "dependencies.redis.calls": 0,
+            "dependencies.telegram.calls": 1,
+            "media.catalog_items": 1,
+            "results.sent": 1,
+        },
+        stages=COMMON_STAGES,
+        fake_telegram_server=fake_telegram_server,
+        fake_statsd_server=fake_statsd_server,
+    )
+
+    await _prepare_catalog(
+        reset_dependency_state=reset_dependency_state,
+        fake_yandex_server=fake_yandex_server,
+        synchronize_media_catalog=synchronize_functional_media_catalog,
+        subscription_types=(FunctionalSubscriptionType(1, "/mixed", time(0), "mixed"),),
+        directories={"mixed": [{"name": "ready.png"}, {"name": "pending.png"}]},
+    )
+    await fake_telegram_server.push_message(text="/mixed")
+    await fake_telegram_server.wait_for_request("editMessageMedia")
+    scenarios["small_mixed"] = await _measure_scenario(
+        query="mixed",
+        expected_results=2,
+        expected_counts={
+            "dependencies.postgres.calls": 2,
+            "dependencies.yandex.calls": 1,
+            "dependencies.redis.calls": 0,
+            "dependencies.telegram.calls": 1,
+            "media.catalog_items": 2,
+            "results.sent": 2,
+        },
+        stages=(*COMMON_STAGES, "media.urls"),
+        fake_telegram_server=fake_telegram_server,
+        fake_statsd_server=fake_statsd_server,
+    )
+
+    await _prepare_catalog(
+        reset_dependency_state=reset_dependency_state,
+        fake_yandex_server=fake_yandex_server,
+        synchronize_media_catalog=synchronize_functional_media_catalog,
+        subscription_types=(FunctionalSubscriptionType(1, "/large", time(0), "large"),),
+        directories={"large": [{"name": f"image-{index}.png"} for index in range(60)]},
+    )
+    scenarios["large_pending"] = await _measure_scenario(
+        query="large",
+        expected_results=50,
+        expected_counts={
+            "dependencies.postgres.calls": 2,
+            "dependencies.yandex.calls": 60,
+            "dependencies.redis.calls": 0,
+            "dependencies.telegram.calls": 1,
+            "media.catalog_items": 60,
+            "results.sent": 50,
+        },
+        stages=(*COMMON_STAGES, "media.urls"),
+        fake_telegram_server=fake_telegram_server,
+        fake_statsd_server=fake_statsd_server,
+    )
+
+    await _prepare_catalog(
+        reset_dependency_state=reset_dependency_state,
+        fake_yandex_server=fake_yandex_server,
+        synchronize_media_catalog=synchronize_functional_media_catalog,
+        subscription_types=(
+            FunctionalSubscriptionType(1, "/first", time(0), "first", ("shared",)),
+            FunctionalSubscriptionType(2, "/second", time(0), "second", ("shared",)),
+        ),
+        directories={
+            "first": [{"name": "first.png"}],
+            "second": [{"name": "second.png"}],
+        },
+    )
+    scenarios["multiple_categories_pending"] = await _measure_scenario(
+        query="shared",
+        expected_results=2,
+        expected_counts={
+            "dependencies.postgres.calls": 2,
+            "dependencies.yandex.calls": 2,
+            "dependencies.redis.calls": 0,
+            "dependencies.telegram.calls": 1,
+            "media.catalog_items": 2,
+            "results.sent": 2,
+        },
+        stages=(*COMMON_STAGES, "media.urls"),
+        fake_telegram_server=fake_telegram_server,
+        fake_statsd_server=fake_statsd_server,
+    )
+
+    print(json.dumps({"runs_per_scenario": RUNS_PER_SCENARIO, "scenarios": scenarios}, sort_keys=True))
+
+
+async def _prepare_catalog(
+    *,
+    reset_dependency_state: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    fake_yandex_server: FakeYandexServer,
+    synchronize_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+    subscription_types: tuple[FunctionalSubscriptionType, ...],
+    directories: dict[str, list[dict[str, Any]]],
+) -> None:
+    await reset_dependency_state(subscription_types)
+    for directory, images in directories.items():
+        await fake_yandex_server.configure_directory(directory, images=images)
+    await synchronize_media_catalog()
+    await fake_yandex_server.reset()
+
+
+async def _measure_scenario(
+    *,
+    query: str,
+    expected_results: int,
+    expected_counts: dict[str, int],
+    stages: Sequence[str],
+    fake_telegram_server: FakeTelegramServer,
+    fake_statsd_server: FakeStatsDServer,
+) -> dict[str, Any]:
+    measurements: list[dict[str, float]] = []
+    observed_counts: dict[str, int] = {}
+    for run in range(RUNS_PER_SCENARIO):
+        await fake_telegram_server.reset()
+        await fake_statsd_server.reset()
+        query_id = f"baseline-{query}-{run}"
+        await fake_telegram_server.push_inline_query(query=query, query_id=query_id)
+        answer = await fake_telegram_server.wait_for_request(
+            "answerInlineQuery",
+            predicate=partial(_has_inline_query_id, query_id=query_id),
+        )
+        assert len(answer["payload"]["results"]) == expected_results
+
+        measurement = {"total": float((await fake_statsd_server.wait_for_metric("functional.inline.total"))["value"])}
+        for stage in stages:
+            metric = await fake_statsd_server.wait_for_metric(f"functional.inline.stages.{stage}")
+            measurement[stage] = float(metric["value"])
+        for name, expected_value in expected_counts.items():
+            metric = await fake_statsd_server.wait_for_metric(f"functional.inline.{name}")
+            value = int(metric["value"])
+            assert value == expected_value
+            if run == 0:
+                observed_counts[name] = value
+        measurements.append(measurement)
+
+    metric_names = measurements[0]
+    return {
+        "first_total_ms": round(measurements[0]["total"], 3),
+        "repeated_total_ms": _summary([measurement["total"] for measurement in measurements[1:]]),
+        "all_runs_ms": {name: _summary([measurement[name] for measurement in measurements]) for name in metric_names},
+        "counts_per_request": observed_counts,
+    }
+
+
+def _summary(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    p95_index = math.ceil(0.95 * len(ordered)) - 1
+    return {
+        "median": round(statistics.median(ordered), 3),
+        "p95": round(ordered[p95_index], 3),
+    }
+
+
+def _has_inline_query_id(request: dict[str, Any], *, query_id: str) -> bool:
+    return request["payload"].get("inline_query_id") == query_id

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -1,6 +1,9 @@
+import asyncio
+import json
+import logging
 from collections.abc import Sequence
 from datetime import UTC, datetime, time
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from aiogram.types import (
@@ -246,6 +249,69 @@ async def test_answer_inline_query_prepares_results_and_disables_telegram_cache(
     ]
 
 
+async def test_answer_inline_query_records_handled_result_error(
+    monkeypatch: MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    subscription_type = _subscription_type(2, "/day", "day")
+    query = _FakeInlineQuery(query="day")
+
+    async def find_subscription_types(query: str) -> list[SubscriptionType]:
+        return [subscription_type]
+
+    async def get_inline_results(subscription_types: list[SubscriptionType]) -> list[inline.InlineMediaResult]:
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(inline, "_find_subscription_types", find_subscription_types)
+    monkeypatch.setattr(inline, "_get_inline_results", get_inline_results)
+
+    with caplog.at_level(logging.INFO):
+        await inline.answer_inline_query(cast(InlineQuery, query))
+
+    assert query.results == []
+    event = _last_inline_metrics_event(caplog)
+    assert event["outcome"] == "handled_error"
+    assert event["counts"]["telegram_calls"] == 1
+
+
+async def test_answer_inline_query_records_and_propagates_unhandled_error(
+    monkeypatch: MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    query = _FakeInlineQuery(query="day")
+
+    async def find_subscription_types(query: str) -> list[SubscriptionType]:
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(inline, "_find_subscription_types", find_subscription_types)
+
+    with caplog.at_level(logging.INFO), pytest.raises(RuntimeError, match="database unavailable"):
+        await inline.answer_inline_query(cast(InlineQuery, query))
+
+    event = _last_inline_metrics_event(caplog)
+    assert event["outcome"] == "unhandled_error"
+    assert event["counts"]["telegram_calls"] == 0
+
+
+async def test_answer_inline_query_records_and_propagates_cancellation(
+    monkeypatch: MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    query = _FakeInlineQuery(query="day")
+
+    async def find_subscription_types(query: str) -> list[SubscriptionType]:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(inline, "_find_subscription_types", find_subscription_types)
+
+    with caplog.at_level(logging.INFO), pytest.raises(asyncio.CancelledError):
+        await inline.answer_inline_query(cast(InlineQuery, query))
+
+    event = _last_inline_metrics_event(caplog)
+    assert event["outcome"] == "cancelled"
+    assert event["counts"]["telegram_calls"] == 0
+
+
 def _inline_results(count: int) -> list[inline.InlineMediaResult]:
     return [
         InlineQueryResultPhoto(
@@ -298,3 +364,11 @@ class _FakeInlineQuery:
 
 class _FakeUser:
     id = 42
+
+
+def _last_inline_metrics_event(caplog: pytest.LogCaptureFixture) -> dict[str, Any]:
+    return next(
+        json.loads(message)
+        for message in reversed(caplog.messages)
+        if message.startswith("{") and '"event":"inline_query_metrics"' in message
+    )

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -10,6 +10,7 @@ from cringe_pics_telebot.repositories.postgres import (
     TelegramMediaType,
 )
 from cringe_pics_telebot.services import inline_images
+from cringe_pics_telebot.services.inline_metrics import InlineQueryMetrics
 from cringe_pics_telebot.services.random_image import CachedMedia, LinkedMedia
 
 
@@ -31,29 +32,38 @@ async def test_get_inline_images_uses_catalog_ids_and_resolves_only_pending_urls
     monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
 
     subscription_type = _subscription_type()
-    assert await inline_images.get_inline_images([subscription_type]) == [
-        (
-            subscription_type,
-            CachedMedia(
-                name="1.png",
-                mime_type="image/png",
-                path="day/1.png",
-                source_revision="sha256:1",
-                id="telegram-file-id",
+    with InlineQueryMetrics.start(query_is_empty=False, clock=lambda: 1) as metrics:
+        assert await inline_images.get_inline_images([subscription_type]) == [
+            (
+                subscription_type,
+                CachedMedia(
+                    name="1.png",
+                    mime_type="image/png",
+                    path="day/1.png",
+                    source_revision="sha256:1",
+                    id="telegram-file-id",
+                ),
             ),
-        ),
-        (
-            subscription_type,
-            LinkedMedia(
-                name="2.png",
-                mime_type="image/png",
-                path="day/2.png",
-                source_revision="sha256:2",
-                url="https://storage.example/day/2.png",
+            (
+                subscription_type,
+                LinkedMedia(
+                    name="2.png",
+                    mime_type="image/png",
+                    path="day/2.png",
+                    source_revision="sha256:2",
+                    url="https://storage.example/day/2.png",
+                ),
             ),
-        ),
-    ]
+        ]
     assert requested_paths == ["day/2.png"]
+    assert metrics.counts.catalog_media == 2
+    assert metrics.counts.selected_media == 2
+    assert metrics.counts.ready_media == 1
+    assert metrics.counts.pending_media == 1
+    assert metrics.counts.url_successes == 1
+    assert metrics.counts.url_failures == 0
+    assert metrics.counts.postgres_calls == 1
+    assert metrics.counts.yandex_calls == 1
 
 
 async def test_get_inline_images_limits_before_resolving_urls(monkeypatch: MonkeyPatch) -> None:

--- a/tests/units/test_inline_metrics.py
+++ b/tests/units/test_inline_metrics.py
@@ -1,0 +1,150 @@
+import json
+import logging
+from collections.abc import Iterable
+
+import pytest
+
+from cringe_pics_telebot.helpers.metrics import CounterMetric, Metric, TimingMetric
+from cringe_pics_telebot.services.inline_metrics import (
+    CATEGORIES_LOOKUP_STAGE,
+    InlineQueryMetrics,
+    inline_query_stage,
+)
+
+
+def test_inline_metrics_emit_correlated_stage_scenario_and_dependency_data(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink = _RecordingMetricsSink()
+    clock = iter((1.0, 1.1, 1.2, 1.5)).__next__
+    with caplog.at_level(logging.INFO):
+        with InlineQueryMetrics.start(
+            query_is_empty=False,
+            sink=sink,
+            clock=clock,
+            correlation_id="correlation-1",
+        ) as metrics:
+            metrics.counts.matched_categories = 2
+            metrics.counts.catalog_media = 3
+            metrics.counts.selected_media = 3
+            metrics.counts.ready_media = 1
+            metrics.counts.pending_media = 2
+            metrics.counts.url_successes = 1
+            metrics.counts.url_failures = 1
+            metrics.counts.results_prepared = 2
+            metrics.counts.results_sent = 2
+            metrics.counts.postgres_calls = 2
+            metrics.counts.yandex_calls = 2
+            metrics.counts.telegram_calls = 1
+            metrics.set_outcome("partial_error")
+
+            with metrics.stage(CATEGORIES_LOOKUP_STAGE):
+                pass
+        metrics.finish()
+
+    assert len(sink.batches) == 1
+    emitted = sink.batches[0]
+    assert CounterMetric("inline.requests") in emitted
+    assert CounterMetric("inline.outcomes.partial_error.requests") in emitted
+    assert CounterMetric("inline.scenarios.mixed.requests") in emitted
+    assert CounterMetric("inline.category_sets.multiple.requests") in emitted
+    assert CounterMetric("inline.catalog_sizes.small.requests") in emitted
+    assert CounterMetric("inline.dependencies.postgres.calls", 2) in emitted
+    assert CounterMetric("inline.dependencies.yandex.calls", 2) in emitted
+    assert CounterMetric("inline.dependencies.redis.calls", 0) in emitted
+    assert CounterMetric("inline.dependencies.telegram.calls", 1) in emitted
+    timings = {metric.name: metric.milliseconds for metric in emitted if isinstance(metric, TimingMetric)}
+    assert timings["inline.stages.categories.lookup"] == pytest.approx(100)
+    assert timings["inline.total"] == pytest.approx(500)
+
+    event = json.loads(caplog.messages[-1])
+    assert event == {
+        "catalog_size": "small",
+        "category_set": "multiple",
+        "correlation_id": "correlation-1",
+        "counts": {
+            "catalog_media": 3,
+            "matched_categories": 2,
+            "pending_media": 2,
+            "postgres_calls": 2,
+            "ready_media": 1,
+            "redis_calls": 0,
+            "results_prepared": 2,
+            "results_sent": 2,
+            "retries": 0,
+            "selected_media": 3,
+            "telegram_calls": 1,
+            "url_failures": 1,
+            "url_successes": 1,
+            "yandex_calls": 2,
+        },
+        "durations_ms": {"categories.lookup": 100.0, "total": 500.0},
+        "event": "inline_query_metrics",
+        "outcome": "partial_error",
+        "scenario": "mixed",
+    }
+
+
+@pytest.mark.parametrize(
+    ("query_is_empty", "matched", "catalog", "ready", "pending", "scenario", "category_set", "size"),
+    [
+        (True, 0, 0, 0, 0, "empty_query", "none", "empty"),
+        (False, 0, 0, 0, 0, "unknown_category", "none", "empty"),
+        (False, 1, 0, 0, 0, "known_empty", "single", "empty"),
+        (False, 1, 2, 2, 0, "catalog_only", "single", "small"),
+        (False, 1, 2, 0, 2, "pending_only", "single", "small"),
+        (False, 2, 51, 1, 50, "mixed", "multiple", "large"),
+    ],
+)
+def test_inline_metrics_classify_low_cardinality_scenarios(
+    query_is_empty: bool,
+    matched: int,
+    catalog: int,
+    ready: int,
+    pending: int,
+    scenario: str,
+    category_set: str,
+    size: str,
+) -> None:
+    with InlineQueryMetrics.start(query_is_empty=query_is_empty, clock=lambda: 1) as metrics:
+        metrics.counts.matched_categories = matched
+        metrics.counts.catalog_media = catalog
+        metrics.counts.ready_media = ready
+        metrics.counts.pending_media = pending
+
+        assert metrics.scenario == scenario
+        assert metrics.category_set == category_set
+        assert metrics.catalog_size == size
+
+
+async def test_inline_stage_decorator_times_sync_and_async_functions() -> None:
+    sink = _RecordingMetricsSink()
+    clock = iter((0.0, 1.0, 1.1, 2.0, 2.2, 3.0)).__next__
+
+    @inline_query_stage("sync")
+    def sync_function(value: int) -> int:
+        return value + 1
+
+    @inline_query_stage("async")
+    async def async_function(value: int) -> int:
+        return value + 2
+
+    with InlineQueryMetrics.start(query_is_empty=True, sink=sink, clock=clock):
+        assert sync_function(1) == 2
+        assert await async_function(1) == 3
+
+    emitted = sink.batches[0]
+    timings = {metric.name: metric.milliseconds for metric in emitted if isinstance(metric, TimingMetric)}
+    assert timings["inline.stages.sync"] == pytest.approx(100)
+    assert timings["inline.stages.async"] == pytest.approx(200)
+
+
+class _RecordingMetricsSink:
+    def __init__(self) -> None:
+        self.batches: list[list[Metric]] = []
+
+    def emit(self, metrics: Iterable[Metric]) -> None:
+        self.batches.append(list(metrics))
+
+    def close(self) -> None:
+        pass

--- a/tests/units/test_metrics.py
+++ b/tests/units/test_metrics.py
@@ -1,0 +1,149 @@
+from types import TracebackType
+from typing import Self
+
+import pytest
+
+from cringe_pics_telebot.helpers.metrics import (
+    CounterMetric,
+    GaugeMetric,
+    NullMetricsSink,
+    StatsDMetricsSink,
+    Stopwatch,
+    TimingMetric,
+    configured_metrics,
+    create_metrics_sink,
+    get_metrics_sink,
+)
+
+
+def test_stopwatch_uses_injected_monotonic_clock() -> None:
+    clock = iter((10.0, 10.125)).__next__
+
+    assert Stopwatch.start(clock=clock).elapsed_milliseconds() == 125
+
+
+def test_create_metrics_sink_disables_metrics_without_host() -> None:
+    factory_called = False
+
+    def client_factory(**kwargs: object) -> _RecordingStatsDClient:
+        nonlocal factory_called
+        factory_called = True
+        return _RecordingStatsDClient()
+
+    sink = create_metrics_sink({}, client_factory=client_factory)
+
+    assert isinstance(sink, NullMetricsSink)
+    assert factory_called is False
+
+
+def test_create_metrics_sink_uses_external_endpoint_and_emits_pipeline() -> None:
+    client = _RecordingStatsDClient()
+    client_arguments: dict[str, object] = {}
+
+    def client_factory(**kwargs: object) -> _RecordingStatsDClient:
+        client_arguments.update(kwargs)
+        return client
+
+    sink = create_metrics_sink(
+        {
+            "STATSD_HOST": "metrics.example.com",
+            "STATSD_PORT": "18125",
+            "STATSD_PREFIX": "test_bot",
+        },
+        client_factory=client_factory,
+    )
+    sink.emit(
+        [
+            TimingMetric("inline.total", 12.5),
+            CounterMetric("inline.requests", 2),
+            GaugeMetric("inline.results", 49),
+        ]
+    )
+
+    assert isinstance(sink, StatsDMetricsSink)
+    assert client_arguments == {
+        "host": "metrics.example.com",
+        "port": 18125,
+        "prefix": "test_bot",
+    }
+    assert client.pipeline_entered is True
+    assert client.pipeline_exited is True
+    assert client.calls == [
+        ("timing", "inline.total", 12.5),
+        ("counter", "inline.requests", 2),
+        ("gauge", "inline.results", 49),
+    ]
+
+
+def test_create_metrics_sink_fails_fast_for_invalid_port() -> None:
+    with pytest.raises(ValueError, match="invalid literal"):
+        create_metrics_sink({"STATSD_HOST": "metrics.example.com", "STATSD_PORT": "invalid"})
+
+
+def test_create_metrics_sink_fails_fast_when_client_initialization_fails() -> None:
+    def client_factory(**kwargs: object) -> _RecordingStatsDClient:
+        raise OSError("DNS unavailable")
+
+    with pytest.raises(OSError, match="DNS unavailable"):
+        create_metrics_sink({"STATSD_HOST": "metrics.example.com"}, client_factory=client_factory)
+
+
+def test_statsd_sink_fails_open_when_pipeline_fails() -> None:
+    client = _RecordingStatsDClient(fail_on_timing=True)
+
+    StatsDMetricsSink(client).emit([TimingMetric("inline.total", 10)])
+
+    assert client.pipeline_entered is True
+    assert client.pipeline_exited is True
+
+
+def test_configured_metrics_restores_previous_sink_and_closes_client() -> None:
+    client = _RecordingStatsDClient()
+    previous_sink = get_metrics_sink()
+
+    with configured_metrics(
+        {"STATSD_HOST": "metrics.example.com"},
+        client_factory=lambda **kwargs: client,
+    ) as configured_sink:
+        assert get_metrics_sink() is configured_sink
+
+    assert get_metrics_sink() is previous_sink
+    assert client.closed is True
+
+
+class _RecordingStatsDClient:
+    def __init__(self, *, fail_on_timing: bool = False) -> None:
+        self.fail_on_timing = fail_on_timing
+        self.calls: list[tuple[str, str, int | float]] = []
+        self.pipeline_entered = False
+        self.pipeline_exited = False
+        self.closed = False
+
+    def pipeline(self) -> _RecordingStatsDClient:
+        return self
+
+    def __enter__(self) -> Self:
+        self.pipeline_entered = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.pipeline_exited = True
+
+    def timing(self, stat: str, delta: float) -> None:
+        if self.fail_on_timing:
+            raise RuntimeError("send failed")
+        self.calls.append(("timing", stat, delta))
+
+    def incr(self, stat: str, count: int = 1) -> None:
+        self.calls.append(("counter", stat, count))
+
+    def gauge(self, stat: str, value: int | float) -> None:
+        self.calls.append(("gauge", stat, value))
+
+    def close(self) -> None:
+        self.closed = True

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,7 @@ dependencies = [
     { name = "redis", extra = ["hiredis"] },
     { name = "serpyco-rs" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "statsd" },
 ]
 
 [package.dev-dependencies]
@@ -316,6 +317,7 @@ requires-dist = [
     { name = "redis", extras = ["hiredis"], specifier = ">=8.1.0" },
     { name = "serpyco-rs", specifier = ">=1.21.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.1.0b3" },
+    { name = "statsd", specifier = ">=4.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1082,6 +1084,15 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "statsd"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/29/05e9f50946f4cf2ed182726c60d9c0ae523bb3f180588c574dd9746de557/statsd-4.0.1.tar.gz", hash = "sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128", size = 27814, upload-time = "2022-11-06T14:17:36.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/d0/c9543b52c067a390ae6ae632d7fd1b97a35cdc8d69d40c0b7d334b326410/statsd-4.0.1-py2.py3-none-any.whl", hash = "sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093", size = 13118, upload-time = "2022-11-06T14:17:34.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #43

## Что изменено

- добавлен типизированный StatsD-клиент для уже существующего внешнего Graphite/StatsD без нового сервиса в Compose;
- подключение настраивается через STATSD_HOST, STATSD_PORT и STATSD_PREFIX; без host используется no-op, явная ошибочная конфигурация останавливает startup, а ошибки UDP-отправки после startup остаются fail-open;
- весь inline request получил монотонный total timer, timers стадий categories lookup, media catalog, Yandex URL, result preparation и Telegram answer;
- добавлены низкокардинальные scenario/outcome timers, counters объёмов и внешних вызовов, а также безопасный structured log с correlation id без query text, user id, URL и токенов;
- добавлен локальный fake StatsD UDP server и functional coverage для fast paths, pending/catalog-only/mixed media, одной/нескольких категорий, large catalog, partial error, cancellation и Telegram limit;
- добавлен opt-in server-side baseline на 5 сценариев по 20 запусков без timing thresholds и произвольных sleep.

## Baseline

Локальный functional harness использует процесс бота, PostgreSQL/Redis Compose и fake Telegram/Yandex/StatsD на одной машине. Это воспроизводимое измерение server-side пути до возврата answerInlineQuery, а не production benchmark.

| Сценарий | total median / p95, ms | Yandex URL median / p95, ms | Вызовы PostgreSQL / Yandex / Redis / Telegram |
| --- | ---: | ---: | ---: |
| small pending, 2 media | 7.608 / 9.619 | 1.434 / 1.906 | 2 / 2 / 0 / 1 |
| small catalog-only, 1 media | 6.017 / 7.644 | — | 2 / 0 / 0 / 1 |
| small mixed, 2 media | 7.587 / 9.854 | 1.448 / 1.734 | 2 / 1 / 0 / 1 |
| large pending, 60 → 50 media | 17.884 / 21.123 | 9.818 / 12.085 | 2 / 60 / 0 / 1 |
| two categories, 2 media | 7.330 / 9.753 | 1.362 / 1.926 | 2 / 2 / 0 / 1 |

Во всех сценариях первое наблюдение и 19 повторных запросов сохраняются отдельно. Локальный harness не показал ускорения повторных запросов, что согласуется с cache_time=0; одиночные первые значения не используются для вывода из-за шума.

Главный подтверждённый bottleneck large pending path — Yandex URL fan-out: 9.818 ms median, около 55% total. На 60 найденных media выполняются 60 запросов, хотя Telegram получает 50. Подготовка результатов занимает 0.355 ms median. Для малого catalog-only path вторичный фактор — два PostgreSQL этапа, суммарно 4.715 ms median.

#15/#17 уже сделали независимый I/O конкурентным, но не ограничили число запросов по полному pending-набору. После #49 ready media читают сохранённый file_id из PostgreSQL и не используют Redis/Yandex; измерения подтверждают redis_calls=0.

Bot API не сообщает момент загрузки и отрисовки inline-превью официальным клиентом. Поэтому автоматические метрики строго заканчиваются на answerInlineQuery. Для оценки client-side части в test/production окружении нужно сопоставить screen recording официального клиента с ближайшим безопасным structured log и вычесть inline.total; в локальном harness устройства и официального клиента нет.

## Рекомендуемый follow-up

Отдельно реализовать ограничение Yandex fan-out: сначала равномерно перемешивать идентификаторы полного набора, затем получать URL порциями до 50 успешных результатов с добором после частичных ошибок. Ожидаемое число успешных запросов уменьшится с N до примерно min(N, 50), сохранив выбор из полного каталога. Основные риски — random semantics, заполнение ответа при partial failure и предел параллелизма. Регрессию измерять через inline.dependencies.yandex.calls, inline.stages.media.urls и текущие behavioral tests.

Объединение PostgreSQL lookup или cache_time следует оценивать отдельно только по production series: первое усложняет alias matching/invalidation, второе меняет свежесть и random semantics.

## Проверки

- Ruff format/check;
- mypy: 95 source files;
- unit: 113 passed;
- functional Docker Compose: 47 passed, 1 opt-in baseline skipped;
- opt-in baseline: 1 passed, 100 inline queries;
- docker compose config;
- локальный UDP payload smoke test, без обращения к внешнему Graphite;
- Crit плана, каждого из трёх коммитов и всей ветки: approved.
