### PR TITLE
Приоритизировать pending-медиа в доставке и ready-медиа в inline-выдаче

### DIFF
--- a/src/cringe_pics_telebot/bot/inline.py
+++ b/src/cringe_pics_telebot/bot/inline.py
@@ -102,7 +102,7 @@ def category_matches_query(query: str, category: str, search_aliases: Sequence[s
 
 
 async def _get_inline_results(subscription_types: list[SubscriptionType]) -> list[InlineMediaResult]:
-    images = await get_inline_images(subscription_types, limit_per_category=None)
+    images = await get_inline_images(subscription_types)
     return _build_inline_results(images)
 
 
@@ -144,17 +144,21 @@ def _prepare_inline_results(
     if not results:
         return []
 
-    selected_result = (chooser or random.choice)(results)
+    cached_results = [result for result in results if _is_cached_inline_result(result)]
+    linked_results = [result for result in results if not _is_cached_inline_result(result)]
+    selected_result = (chooser or random.choice)(cached_results or linked_results)
     random_result = selected_result.model_copy(
         update={
             "id": _random_result_id(selected_result.id),
             "title": RANDOM_INLINE_RESULT_TITLE,
         }
     )
-    ordinary_results = [result for result in results if result.id != selected_result.id]
-    shuffled_results = _shuffle_inline_results(ordinary_results, shuffler=shuffler)
+    ordinary_cached = [result for result in cached_results if result.id != selected_result.id]
+    ordinary_linked = [result for result in linked_results if result.id != selected_result.id]
+    shuffled_cached = _shuffle_inline_results(ordinary_cached, shuffler=shuffler) if ordinary_cached else []
+    shuffled_linked = _shuffle_inline_results(ordinary_linked, shuffler=shuffler) if ordinary_linked else []
 
-    return [random_result, *shuffled_results[: MAX_INLINE_QUERY_RESULTS - 1]]
+    return [random_result, *shuffled_cached, *shuffled_linked][:MAX_INLINE_QUERY_RESULTS]
 
 
 def _random_result_id(result_id: str) -> str:
@@ -169,6 +173,10 @@ def _shuffle_inline_results(
     shuffled_results = results.copy()
     (shuffler or random.shuffle)(shuffled_results)
     return shuffled_results
+
+
+def _is_cached_inline_result(result: InlineMediaResult) -> bool:
+    return isinstance(result, InlineQueryResultCachedGif | InlineQueryResultCachedPhoto)
 
 
 def _inline_result(

--- a/src/cringe_pics_telebot/services/inline_images.py
+++ b/src/cringe_pics_telebot/services/inline_images.py
@@ -1,4 +1,5 @@
-from collections.abc import Sequence
+import random
+from collections.abc import Callable, MutableSequence, Sequence
 
 from cringe_pics_telebot.repositories.postgres import (
     CategoryMedia,
@@ -18,32 +19,28 @@ from .inline_metrics import (
 
 MAX_INLINE_QUERY_RESULTS = 50
 
+type MediaShuffler = Callable[[MutableSequence[CategoryMedia]], None]
+
 
 async def get_inline_images(
     subscription_types: Sequence[SubscriptionType],
     *,
-    limit_per_category: int | None = MAX_INLINE_QUERY_RESULTS,
+    limit: int | None = MAX_INLINE_QUERY_RESULTS,
+    shuffler: MediaShuffler | None = None,
 ) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
     media = await _get_catalog_media([item.id for item in subscription_types])
     metrics = get_inline_query_metrics()
     if metrics is not None:
         metrics.counts.catalog_media = len(media)
 
-    media_by_category: dict[int, list[CategoryMedia]] = {}
-    for item in media:
-        category_media = media_by_category.setdefault(item.subscription_type_id, [])
-        if limit_per_category is None or len(category_media) < limit_per_category:
-            category_media.append(item)
+    selected_media = _select_inline_media(
+        media,
+        subscription_types=subscription_types,
+        limit=limit,
+        shuffler=shuffler,
+    )
 
-    selected_media: list[CategoryMedia] = []
-    seen_paths: set[str] = set()
-    for subscription_type in subscription_types:
-        for item in media_by_category.get(subscription_type.id, []):
-            if item.source_path not in seen_paths:
-                seen_paths.add(item.source_path)
-                selected_media.append(item)
-
-    pending_paths = list(dict.fromkeys(item.source_path for item in selected_media if item.telegram_file_id is None))
+    pending_paths = [item.source_path for item in selected_media if item.telegram_file_id is None]
     if metrics is not None:
         metrics.counts.selected_media = len(selected_media)
         metrics.counts.ready_media = len(selected_media) - len(pending_paths)
@@ -62,6 +59,34 @@ async def get_inline_images(
         subscription_types=subscription_types,
         download_urls_by_path=download_urls_by_path,
     )
+
+
+def _select_inline_media(
+    media: Sequence[CategoryMedia],
+    *,
+    subscription_types: Sequence[SubscriptionType],
+    limit: int | None,
+    shuffler: MediaShuffler | None = None,
+) -> list[CategoryMedia]:
+    media_by_category: dict[int, list[CategoryMedia]] = {}
+    for item in media:
+        media_by_category.setdefault(item.subscription_type_id, []).append(item)
+
+    media_by_path: dict[str, CategoryMedia] = {}
+    for subscription_type in subscription_types:
+        for item in media_by_category.get(subscription_type.id, []):
+            existing = media_by_path.get(item.source_path)
+            if existing is None or (existing.telegram_file_id is None and item.telegram_file_id is not None):
+                media_by_path[item.source_path] = item
+
+    ready = [item for item in media_by_path.values() if item.telegram_file_id is not None]
+    pending = [item for item in media_by_path.values() if item.telegram_file_id is None]
+    shuffle = shuffler or random.shuffle
+    shuffle(ready)
+    shuffle(pending)
+
+    selected = [*ready, *pending]
+    return selected if limit is None else selected[:limit]
 
 
 @inline_query_stage(MEDIA_CATALOG_STAGE)

--- a/src/cringe_pics_telebot/services/random_image.py
+++ b/src/cringe_pics_telebot/services/random_image.py
@@ -1,8 +1,15 @@
 import random
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
-from cringe_pics_telebot.repositories.postgres import CategoryMedia, get_category_media_by_subscription_types
+from cringe_pics_telebot.repositories.postgres import (
+    CategoryMedia,
+    CategoryMediaStatus,
+    get_category_media_by_subscription_types,
+)
 from cringe_pics_telebot.repositories.yandex import Image
+
+type MediaChooser = Callable[[Sequence[CategoryMedia]], CategoryMedia]
 
 
 @dataclass(slots=True)
@@ -17,6 +24,27 @@ class CachedMedia(Image):
     """Идентификатор картинки на серверах Telegram"""
 
 
-async def get_random_image(category_id: int | None = None) -> CategoryMedia:
+def choose_random_image(
+    media: Sequence[CategoryMedia],
+    *,
+    chooser: MediaChooser | None = None,
+) -> CategoryMedia:
+    pending = [item for item in media if item.status is CategoryMediaStatus.pending]
+    ready = [item for item in media if item.status is CategoryMediaStatus.ready]
+    candidates = pending or ready
+    if not candidates:
+        raise NoCategoryMediaError
+    return (chooser or random.choice)(candidates)
+
+
+async def get_random_image(
+    category_id: int | None = None,
+    *,
+    chooser: MediaChooser | None = None,
+) -> CategoryMedia:
     category_ids = None if category_id is None else [category_id]
-    return random.choice(await get_category_media_by_subscription_types(category_ids))
+    media = await get_category_media_by_subscription_types(category_ids)
+    return choose_random_image(media, chooser=chooser)
+
+
+class NoCategoryMediaError(LookupError): ...

--- a/src/cringe_pics_telebot/services/subscription_broadcasts.py
+++ b/src/cringe_pics_telebot/services/subscription_broadcasts.py
@@ -1,15 +1,19 @@
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime, time, timedelta, timezone
 
 from aiogram import Bot
 
 from cringe_pics_telebot.bot.media import send_image_to_chat
 from cringe_pics_telebot.repositories import redis as cache
-from cringe_pics_telebot.repositories.postgres import SubscriptionType
+from cringe_pics_telebot.repositories.postgres import (
+    CategoryMedia,
+    SubscriptionType,
+    get_category_media_by_subscription_types,
+)
 from cringe_pics_telebot.services.media_delivery import deliver_category_media
-from cringe_pics_telebot.services.random_image import get_random_image
+from cringe_pics_telebot.services.random_image import choose_random_image
 from cringe_pics_telebot.services.scheduler import aware_datetime, seconds_until_next_tick, validate_interval
 from cringe_pics_telebot.services.subscriptions import get_subscription_types, get_subscription_users
 
@@ -69,6 +73,10 @@ async def _broadcast_subscription_type(*, bot: Bot, subscription_type: Subscript
     if not users:
         return 0
 
+    media = await get_category_media_by_subscription_types([subscription_type.id])
+    if not media:
+        return 0
+
     reservations = await asyncio.gather(
         *(
             _reserve_scheduled_send(
@@ -90,6 +98,7 @@ async def _broadcast_subscription_type(*, bot: Bot, subscription_type: Subscript
                 bot=bot,
                 user_id=user_id,
                 subscription_type=subscription_type,
+                media=media,
             )
             for user_id in reserved_user_ids
         )
@@ -103,11 +112,12 @@ async def _send_scheduled_image_to_user(
     bot: Bot,
     user_id: int,
     subscription_type: SubscriptionType,
+    media: Sequence[CategoryMedia],
 ) -> int:
     try:
-        media = await get_random_image(subscription_type.id)
+        selected_media = choose_random_image(media)
         await deliver_category_media(
-            media,
+            selected_media,
             send=lambda image: send_image_to_chat(bot=bot, chat_id=user_id, image=image),
         )
     except Exception:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -519,8 +519,8 @@ async def bot_process(
         "bot",
         cwd=ROOT_DIR,
         env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     try:
         await fake_telegram_server.wait_for_request("getMe", timeout=30)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -868,6 +868,51 @@ async def read_user_timezone_offset(
 
 
 @pytest.fixture
+async def set_functional_category_media_file_ids(
+    docker_compose: DependencyPorts,
+) -> Callable[[dict[str, str | None]], Awaitable[None]]:
+    async def set_file_ids(file_ids_by_path: dict[str, str | None]) -> None:
+        connection = await _create_postgres_connection(docker_compose)
+        try:
+            await connection.executemany(
+                """
+                UPDATE category_media
+                SET telegram_file_id = $2,
+                    telegram_file_unique_id = CASE WHEN $2::text IS NULL THEN NULL ELSE 'unique:' || $2 END,
+                    materialized_at = CASE WHEN $2::text IS NULL THEN NULL ELSE now() END,
+                    updated_at = now()
+                WHERE source_path = $1
+                """,
+                list(file_ids_by_path.items()),
+            )
+        finally:
+            await connection.close()
+
+    return set_file_ids
+
+
+@pytest.fixture
+async def read_functional_category_media_states(
+    docker_compose: DependencyPorts,
+) -> Callable[[], Awaitable[dict[str, tuple[str, str | None]]]]:
+    async def read() -> dict[str, tuple[str, str | None]]:
+        connection = await _create_postgres_connection(docker_compose)
+        try:
+            rows = await connection.fetch(
+                """
+                SELECT source_path, status, telegram_file_id
+                FROM category_media
+                ORDER BY source_path
+                """
+            )
+            return {row["source_path"]: (row["status"], row["telegram_file_id"]) for row in rows}
+        finally:
+            await connection.close()
+
+    return read
+
+
+@pytest.fixture
 def run_subscription_broadcasts_at(
     docker_compose: DependencyPorts,
     fake_telegram_server: FakeTelegramServer,

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -633,9 +633,56 @@ async def test_inline_metrics_cover_large_catalog_and_telegram_limit(
         "functional.inline.results.sent",
     )
     assert metrics["functional.inline.media.catalog_items"]["value"] == 60
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 60
-    assert metrics["functional.inline.results.prepared"]["value"] == 60
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 50
+    assert metrics["functional.inline.results.prepared"]["value"] == 50
     assert metrics["functional.inline.results.sent"]["value"] == 50
+
+
+async def test_inline_uses_ready_media_to_fill_limit_without_pending_urls(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    fake_statsd_server: FakeStatsDServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+    set_functional_category_media_file_ids: Callable[[dict[str, str | None]], Awaitable[None]],
+) -> None:
+    await seed_functional_subscription_types((FunctionalSubscriptionType(1, "/large", time(0), "large"),))
+    await fake_yandex_server.configure_directory(
+        "large",
+        images=[{"name": f"image-{index}.png"} for index in range(51)],
+    )
+    await synchronize_functional_media_catalog()
+    await set_functional_category_media_file_ids(
+        {f"large/image-{index}.png": f"functional-ready-{index}" for index in range(50)}
+    )
+    await fake_telegram_server.reset()
+    await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
+
+    await fake_telegram_server.push_inline_query(query="large", query_id="inline-ready-limit")
+    answer = await fake_telegram_server.wait_for_request(
+        "answerInlineQuery",
+        predicate=lambda request: request["payload"].get("inline_query_id") == "inline-ready-limit",
+    )
+
+    results = answer["payload"]["results"]
+    assert len(results) == 50
+    assert results[0]["title"] == "🎲 Выбрать случайную картинку"
+    assert all("photo_file_id" in result and "photo_url" not in result for result in results)
+    assert not await fake_yandex_server.requests()
+
+    metrics = await _wait_for_metrics(
+        fake_statsd_server,
+        "functional.inline.media.catalog_items",
+        "functional.inline.media.ready_items",
+        "functional.inline.media.pending_items",
+        "functional.inline.dependencies.yandex.calls",
+    )
+    assert metrics["functional.inline.media.catalog_items"]["value"] == 51
+    assert metrics["functional.inline.media.ready_items"]["value"] == 50
+    assert metrics["functional.inline.media.pending_items"]["value"] == 0
+    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
 
 
 async def test_inline_excludes_media_deactivated_by_later_sync(

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -222,6 +222,36 @@ async def test_bot_sends_image_for_subscription_category(
     assert not any(request["method"] == "download" for request in yandex_requests)
 
 
+async def test_bot_prefers_pending_media_over_ready_for_ordinary_delivery(
+    bot_process: subprocess.Process,
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    seeded_subscription_types: tuple[FunctionalSubscriptionType, ...],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+    set_functional_category_media_file_ids: Callable[[dict[str, str | None]], Awaitable[None]],
+    read_functional_category_media_states: Callable[[], Awaitable[dict[str, tuple[str, str | None]]]],
+) -> None:
+    await fake_yandex_server.configure_directory(
+        "day",
+        images=[{"name": "ready.png"}, {"name": "pending.png"}],
+    )
+    await synchronize_functional_media_catalog()
+    await set_functional_category_media_file_ids({"day/ready.png": "functional-ready-file-id"})
+    await fake_telegram_server.reset()
+    await fake_yandex_server.reset()
+
+    await fake_telegram_server.push_message(text="/day")
+    edit_media = await fake_telegram_server.wait_for_request("editMessageMedia")
+
+    assert edit_media["payload"]["media"]["media"] == (f"{fake_yandex_server.base_url}/download/pending.png")
+    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
+    states = await read_functional_category_media_states()
+    assert {path: state for path, state in states.items() if path.startswith("day/")} == {
+        "day/pending.png": ("ready", "functional-photo-file-id"),
+        "day/ready.png": ("ready", "functional-ready-file-id"),
+    }
+
+
 async def test_bot_recovers_invalid_catalog_file_id_once(
     bot_process: subprocess.Process,
     fake_telegram_server: FakeTelegramServer,

--- a/tests/functional/test_inline_latency_baseline.py
+++ b/tests/functional/test_inline_latency_baseline.py
@@ -127,7 +127,7 @@ async def test_collect_inline_latency_baseline(
         expected_results=50,
         expected_counts={
             "dependencies.postgres.calls": 2,
-            "dependencies.yandex.calls": 60,
+            "dependencies.yandex.calls": 50,
             "dependencies.redis.calls": 0,
             "dependencies.telegram.calls": 1,
             "media.catalog_items": 60,

--- a/tests/functional/test_subscription_broadcasts.py
+++ b/tests/functional/test_subscription_broadcasts.py
@@ -81,6 +81,44 @@ async def test_subscription_broadcasts_skip_empty_category(
     assert not await fake_yandex_server.requests()
 
 
+async def test_subscription_broadcast_prefers_pending_media_over_ready(
+    fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    create_user_subscription: Callable[..., Awaitable[None]],
+    run_subscription_broadcasts_at: Callable[[datetime], Awaitable[int]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
+    set_functional_category_media_file_ids: Callable[[dict[str, str | None]], Awaitable[None]],
+    read_functional_category_media_states: Callable[[], Awaitable[dict[str, tuple[str, str | None]]]],
+) -> None:
+    await seed_functional_subscription_types((FunctionalSubscriptionType(1, "/morning", time(10, 0), "morning"),))
+    await create_user_subscription(
+        user_id=700,
+        subscription_type_id=1,
+        timezone_offset_minutes=7 * 60,
+    )
+    await fake_yandex_server.configure_directory(
+        "morning",
+        images=[{"name": "ready.png"}, {"name": "pending.png"}],
+    )
+    await synchronize_functional_media_catalog()
+    await set_functional_category_media_file_ids({"morning/ready.png": "functional-ready-file-id"})
+    await fake_telegram_server.reset()
+    await fake_yandex_server.reset()
+
+    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)) == 1
+
+    send_photo_requests = await fake_telegram_server.requests(method="sendPhoto")
+    assert [request["payload"]["photo"] for request in send_photo_requests] == [
+        f"{fake_yandex_server.base_url}/download/pending.png"
+    ]
+    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
+    assert await read_functional_category_media_states() == {
+        "morning/pending.png": ("ready", "functional-photo-file-id"),
+        "morning/ready.png": ("ready", "functional-ready-file-id"),
+    }
+
+
 async def test_concurrent_scheduled_recipients_materialize_one_pending_revision_once(
     fake_telegram_server: FakeTelegramServer,
     fake_yandex_server: FakeYandexServer,

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -67,11 +67,8 @@ async def test_get_inline_results_combines_categories_without_duplicate_paths(mo
 
     async def get_inline_images(
         subscription_types: list[SubscriptionType],
-        *,
-        limit_per_category: int | None,
     ) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
         assert subscription_types == [morning, evening]
-        assert limit_per_category is None
         return [
             (
                 morning,
@@ -174,6 +171,46 @@ def test_prepare_inline_results_chooses_before_limit_and_deduplicates_selected_m
     assert [result.id for result in results] == [
         f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 2)
     ]
+
+
+def test_prepare_inline_results_prefers_cached_for_random_and_keeps_status_groups() -> None:
+    results: list[inline.InlineMediaResult] = [
+        InlineQueryResultPhoto(
+            id="linked-1",
+            photo_url="https://storage.example/linked-1.png",
+            thumbnail_url="https://storage.example/linked-1.png",
+        ),
+        InlineQueryResultCachedPhoto(id="cached-1", photo_file_id="telegram-1"),
+        InlineQueryResultPhoto(
+            id="linked-2",
+            photo_url="https://storage.example/linked-2.png",
+            thumbnail_url="https://storage.example/linked-2.png",
+        ),
+        InlineQueryResultCachedPhoto(id="cached-2", photo_file_id="telegram-2"),
+    ]
+    chooser_inputs: list[list[str]] = []
+    shuffler_inputs: list[list[str]] = []
+
+    def choose_last(items: Sequence[inline.InlineMediaResult]) -> inline.InlineMediaResult:
+        chooser_inputs.append([item.id for item in items])
+        return items[-1]
+
+    def reverse(items: list[inline.InlineMediaResult]) -> None:
+        shuffler_inputs.append([item.id for item in items])
+        items.reverse()
+
+    prepared = inline._prepare_inline_results(
+        results,
+        chooser=choose_last,
+        shuffler=reverse,
+    )
+    random_result = cast(InlineQueryResultCachedPhoto, prepared[0])
+
+    assert chooser_inputs == [["cached-1", "cached-2"]]
+    assert shuffler_inputs == [["cached-1"], ["linked-1", "linked-2"]]
+    assert random_result.photo_file_id == "telegram-2"
+    assert random_result.title == inline.RANDOM_INLINE_RESULT_TITLE
+    assert [result.id for result in prepared[1:]] == ["cached-1", "linked-2", "linked-1"]
 
 
 def test_prepare_inline_results_returns_empty_results() -> None:

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableSequence
 from datetime import UTC, datetime, time
 
 from pytest import MonkeyPatch
@@ -33,7 +33,7 @@ async def test_get_inline_images_uses_catalog_ids_and_resolves_only_pending_urls
 
     subscription_type = _subscription_type()
     with InlineQueryMetrics.start(query_is_empty=False, clock=lambda: 1) as metrics:
-        assert await inline_images.get_inline_images([subscription_type]) == [
+        assert await inline_images.get_inline_images([subscription_type], shuffler=_keep_order) == [
             (
                 subscription_type,
                 CachedMedia(
@@ -66,7 +66,7 @@ async def test_get_inline_images_uses_catalog_ids_and_resolves_only_pending_urls
     assert metrics.counts.yandex_calls == 1
 
 
-async def test_get_inline_images_limits_before_resolving_urls(monkeypatch: MonkeyPatch) -> None:
+async def test_get_inline_images_applies_global_limit_before_resolving_urls(monkeypatch: MonkeyPatch) -> None:
     media = [_media(index) for index in range(52)]
     requested_paths: list[str] = []
 
@@ -81,7 +81,7 @@ async def test_get_inline_images_limits_before_resolving_urls(monkeypatch: Monke
     )
     monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
 
-    results = await inline_images.get_inline_images([_subscription_type()])
+    results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
 
     assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
     assert requested_paths == [f"day/{index}.png" for index in range(50)]
@@ -101,7 +101,7 @@ async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: Mo
     )
 
     subscription_type = _subscription_type()
-    assert await inline_images.get_inline_images([subscription_type]) == [
+    assert await inline_images.get_inline_images([subscription_type], shuffler=_keep_order) == [
         (
             subscription_type,
             LinkedMedia(
@@ -115,16 +115,151 @@ async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: Mo
     ]
 
 
+async def test_get_inline_images_uses_only_ready_when_ready_fills_limit(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    media = [*[_media(index, file_id=f"telegram-{index}") for index in range(50)], _media(50)]
+    url_resolution_attempted = False
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        nonlocal url_resolution_attempted
+        url_resolution_attempted = True
+        return []
+
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result(media),
+    )
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
+
+    assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
+    assert all(isinstance(image, CachedMedia) for _, image in results)
+    assert url_resolution_attempted is False
+
+
+async def test_get_inline_images_fills_only_remaining_places_with_pending(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    media = [
+        *[_media(index, file_id=f"telegram-{index}") for index in range(48)],
+        *[_media(index) for index in range(48, 51)],
+    ]
+    requested_paths: list[str] = []
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        requested_paths.extend(paths)
+        return [f"https://storage.example/{path}" for path in paths]
+
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result(media),
+    )
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
+
+    assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
+    assert sum(isinstance(image, CachedMedia) for _, image in results) == 48
+    assert sum(isinstance(image, LinkedMedia) for _, image in results) == 2
+    assert requested_paths == ["day/48.png", "day/49.png"]
+
+
+async def test_get_inline_images_prefers_ready_duplicate_across_categories(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    morning = _subscription_type(1, name="/morning", directory="morning")
+    day = _subscription_type(2, name="/day", directory="day")
+    media = [
+        _media(1, category_id=1, source_path="shared/image.png"),
+        _media(
+            2,
+            category_id=2,
+            source_path="shared/image.png",
+            file_id="telegram-shared",
+        ),
+    ]
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result(media),
+    )
+
+    results = await inline_images.get_inline_images([morning, day], shuffler=_keep_order)
+
+    assert results == [
+        (
+            day,
+            CachedMedia(
+                name="2.png",
+                mime_type="image/png",
+                path="shared/image.png",
+                source_revision="sha256:2",
+                id="telegram-shared",
+            ),
+        )
+    ]
+
+
+def test_select_inline_media_shuffles_ready_and_pending_independently() -> None:
+    media = [
+        _media(1, file_id="telegram-1"),
+        _media(2, file_id="telegram-2"),
+        _media(3),
+        _media(4),
+    ]
+    shuffled_inputs: list[list[int]] = []
+
+    def reverse(items: MutableSequence[CategoryMedia]) -> None:
+        shuffled_inputs.append([item.id for item in items])
+        items.reverse()
+
+    selected = inline_images._select_inline_media(
+        media,
+        subscription_types=[_subscription_type()],
+        limit=None,
+        shuffler=reverse,
+    )
+
+    assert shuffled_inputs == [[1, 2], [3, 4]]
+    assert [item.id for item in selected] == [2, 1, 4, 3]
+
+
+async def test_get_inline_images_returns_empty_without_url_resolution(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result([]),
+    )
+
+    assert await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order) == []
+
+
 async def _async_result[T](value: T) -> T:
     return value
 
 
-def _media(media_id: int, *, file_id: str | None = None) -> CategoryMedia:
+def _keep_order(items: MutableSequence[CategoryMedia]) -> None:
+    return None
+
+
+def _media(
+    media_id: int,
+    *,
+    category_id: int = 2,
+    source_path: str | None = None,
+    file_id: str | None = None,
+) -> CategoryMedia:
     now = datetime(2026, 8, 19, tzinfo=UTC)
     return CategoryMedia(
         id=media_id,
-        subscription_type_id=2,
-        source_path=f"day/{media_id}.png",
+        subscription_type_id=category_id,
+        source_path=source_path or f"day/{media_id}.png",
         source_revision=f"sha256:{media_id}",
         name=f"{media_id}.png",
         mime_type="image/png",
@@ -140,13 +275,18 @@ def _media(media_id: int, *, file_id: str | None = None) -> CategoryMedia:
     )
 
 
-def _subscription_type() -> SubscriptionType:
+def _subscription_type(
+    subscription_type_id: int = 2,
+    *,
+    name: str = "/day",
+    directory: str = "day",
+) -> SubscriptionType:
     now = datetime(2026, 8, 19, tzinfo=UTC)
     return SubscriptionType(
-        id=2,
-        name="/day",
+        id=subscription_type_id,
+        name=name,
         time=time(13),
-        s3_directory_path="day",
+        s3_directory_path=directory,
         search_aliases=(),
         created_at=now,
         updated_at=now,

--- a/tests/units/test_random_image.py
+++ b/tests/units/test_random_image.py
@@ -1,0 +1,95 @@
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import pytest
+from pytest import MonkeyPatch
+
+from cringe_pics_telebot.repositories.postgres import (
+    CategoryMedia,
+    CategoryMediaStatus,
+    TelegramMediaType,
+)
+from cringe_pics_telebot.services import random_image
+
+
+def test_choose_random_image_prefers_pending_and_injects_chooser() -> None:
+    ready = _media(1, status=CategoryMediaStatus.ready)
+    first_pending = _media(2, status=CategoryMediaStatus.pending)
+    second_pending = _media(3, status=CategoryMediaStatus.pending)
+    chooser_inputs: list[list[int]] = []
+
+    def choose_last(items: Sequence[CategoryMedia]) -> CategoryMedia:
+        chooser_inputs.append([item.id for item in items])
+        return items[-1]
+
+    selected = random_image.choose_random_image(
+        [ready, first_pending, second_pending],
+        chooser=choose_last,
+    )
+
+    assert selected is second_pending
+    assert chooser_inputs == [[2, 3]]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [CategoryMediaStatus.pending, CategoryMediaStatus.ready],
+)
+def test_choose_random_image_chooses_from_single_status(status: CategoryMediaStatus) -> None:
+    media = _media(1, status=status)
+
+    assert random_image.choose_random_image([media], chooser=_choose_only) is media
+
+
+@pytest.mark.parametrize("statuses", [(), (CategoryMediaStatus.inactive,)])
+def test_choose_random_image_rejects_unavailable_candidate_set(
+    statuses: tuple[CategoryMediaStatus, ...],
+) -> None:
+    with pytest.raises(random_image.NoCategoryMediaError):
+        random_image.choose_random_image(
+            [_media(index, status=status) for index, status in enumerate(statuses, start=1)]
+        )
+
+
+async def test_get_random_image_fetches_category_once_and_applies_policy(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ready = _media(1, status=CategoryMediaStatus.ready)
+    pending = _media(2, status=CategoryMediaStatus.pending)
+    requested_category_ids: list[list[int] | None] = []
+
+    async def get_media(category_ids: list[int] | None) -> list[CategoryMedia]:
+        requested_category_ids.append(category_ids)
+        return [ready, pending]
+
+    monkeypatch.setattr(random_image, "get_category_media_by_subscription_types", get_media)
+
+    assert await random_image.get_random_image(7, chooser=_choose_only) is pending
+    assert requested_category_ids == [[7]]
+
+
+def _choose_only(items: Sequence[CategoryMedia]) -> CategoryMedia:
+    (selected,) = items
+    return selected
+
+
+def _media(media_id: int, *, status: CategoryMediaStatus) -> CategoryMedia:
+    now = datetime(2026, 8, 25, tzinfo=UTC)
+    ready = status is CategoryMediaStatus.ready
+    return CategoryMedia(
+        id=media_id,
+        subscription_type_id=7,
+        source_path=f"day/{media_id}.png",
+        source_revision=f"sha256:{media_id}",
+        name=f"{media_id}.png",
+        mime_type="image/png",
+        telegram_media_type=TelegramMediaType.photo,
+        telegram_file_id=f"telegram-{media_id}" if ready else None,
+        telegram_file_unique_id=f"unique-{media_id}" if ready else None,
+        is_active=status is not CategoryMediaStatus.inactive,
+        status=status,
+        last_seen_at=now,
+        materialized_at=now if ready else None,
+        created_at=now,
+        updated_at=now,
+    )

--- a/tests/units/test_subscription_broadcasts.py
+++ b/tests/units/test_subscription_broadcasts.py
@@ -1,7 +1,18 @@
 from datetime import UTC, datetime, time, timedelta, timezone
+from typing import cast
 
 import pytest
+from aiogram import Bot
+from pytest import MonkeyPatch
 
+from cringe_pics_telebot.repositories.postgres import (
+    CategoryMedia,
+    CategoryMediaStatus,
+    SubscriptionType,
+    TelegramMediaType,
+    User,
+)
+from cringe_pics_telebot.services import subscription_broadcasts
 from cringe_pics_telebot.services.subscription_broadcasts import _same_local_minute
 
 
@@ -35,4 +46,117 @@ def test_same_local_minute(
             timezone_offset_minutes=timezone_offset_minutes,
         )
         is expected
+    )
+
+
+async def test_broadcast_fetches_media_once_and_prefers_pending_for_every_recipient(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    now = datetime(2026, 8, 25, 3, 0, tzinfo=UTC)
+    subscription_type = _subscription_type()
+    users = [_user(701), _user(702)]
+    ready = _media(1, status=CategoryMediaStatus.ready)
+    pending = _media(2, status=CategoryMediaStatus.pending)
+    requested_category_ids: list[list[int]] = []
+    delivered: list[CategoryMedia] = []
+
+    async def get_users(subscription_type_id: int) -> list[User]:
+        assert subscription_type_id == subscription_type.id
+        return users
+
+    async def get_media(category_ids: list[int]) -> list[CategoryMedia]:
+        requested_category_ids.append(category_ids)
+        return [ready, pending]
+
+    async def reserve(**kwargs: object) -> bool:
+        return True
+
+    async def deliver(media: CategoryMedia, **kwargs: object) -> None:
+        delivered.append(media)
+
+    monkeypatch.setattr(subscription_broadcasts, "get_subscription_users", get_users)
+    monkeypatch.setattr(subscription_broadcasts, "get_category_media_by_subscription_types", get_media)
+    monkeypatch.setattr(subscription_broadcasts, "_reserve_scheduled_send", reserve)
+    monkeypatch.setattr(subscription_broadcasts, "deliver_category_media", deliver)
+
+    sent = await subscription_broadcasts._broadcast_subscription_type(
+        bot=cast(Bot, object()),
+        subscription_type=subscription_type,
+        current_time=now,
+    )
+
+    assert sent == 2
+    assert requested_category_ids == [[subscription_type.id]]
+    assert delivered == [pending, pending]
+
+
+async def test_broadcast_does_not_reserve_empty_category(monkeypatch: MonkeyPatch) -> None:
+    reservation_attempted = False
+
+    async def get_users(subscription_type_id: int) -> list[User]:
+        return [_user(701)]
+
+    async def get_media(category_ids: list[int]) -> list[CategoryMedia]:
+        return []
+
+    async def reserve(**kwargs: object) -> bool:
+        nonlocal reservation_attempted
+        reservation_attempted = True
+        return True
+
+    monkeypatch.setattr(subscription_broadcasts, "get_subscription_users", get_users)
+    monkeypatch.setattr(subscription_broadcasts, "get_category_media_by_subscription_types", get_media)
+    monkeypatch.setattr(subscription_broadcasts, "_reserve_scheduled_send", reserve)
+
+    sent = await subscription_broadcasts._broadcast_subscription_type(
+        bot=cast(Bot, object()),
+        subscription_type=_subscription_type(),
+        current_time=datetime(2026, 8, 25, 3, 0, tzinfo=UTC),
+    )
+
+    assert sent == 0
+    assert reservation_attempted is False
+
+
+def _subscription_type() -> SubscriptionType:
+    now = datetime(2026, 8, 25, tzinfo=UTC)
+    return SubscriptionType(
+        id=1,
+        name="/morning",
+        time=time(10, 0),
+        s3_directory_path="morning",
+        search_aliases=(),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _user(user_id: int) -> User:
+    return User(
+        id=user_id,
+        timezone_offset_minutes=7 * 60,
+        is_active=True,
+        created_at=datetime(2026, 8, 25, tzinfo=UTC),
+    )
+
+
+def _media(media_id: int, *, status: CategoryMediaStatus) -> CategoryMedia:
+    now = datetime(2026, 8, 25, tzinfo=UTC)
+    ready = status is CategoryMediaStatus.ready
+    return CategoryMedia(
+        id=media_id,
+        subscription_type_id=1,
+        source_path=f"morning/{media_id}.png",
+        source_revision=f"sha256:{media_id}",
+        name=f"{media_id}.png",
+        mime_type="image/png",
+        telegram_media_type=TelegramMediaType.photo,
+        telegram_file_id=f"telegram-{media_id}" if ready else None,
+        telegram_file_unique_id=f"unique-{media_id}" if ready else None,
+        is_active=True,
+        status=status,
+        last_seen_at=now,
+        materialized_at=now if ready else None,
+        created_at=now,
+        updated_at=now,
     )


### PR DESCRIPTION
Closes #53

## Что изменено

- обычная выдача и плановые рассылки выбирают `pending` среди допустимых кандидатов, пока такие медиа есть;
- плановая рассылка загружает каталог категории один раз на пакет получателей вместо PostgreSQL N+1;
- inline дедуплицирует общий набор по `source_path`, независимо перемешивает статусные группы и заполняет лимит ready-first;
- специальный результат 🎲 выбирается из cached/ready при наличии готовых кандидатов;
- Yandex URL запрашиваются только для `pending`, попавших в глобальный лимит 50;
- functional bot subprocess больше не блокируется на заполненном log pipe во время повторяемого latency baseline.

## Проверки

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run pytest tests/units -q` — 127 passed
- `uv run pytest tests/functional -q` — 50 passed, 1 skipped
- `docker compose -f compose.yml -f tests/functional/compose.functional-tests.yml config --quiet`
- opt-in inline latency baseline — 1 passed, 5 сценариев × 20 запусков; large pending: 50 Yandex calls, median 17.472 ms, p95 19.158 ms

## Review

Оба атомарных коммита и финальный diff ветки одобрены в Crit.