### PR TITLE
Добавить случайное inline-медиа по категориям для пустого запроса

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Agent plans
+.agents/plans/
+.codex/plans/

--- a/src/cringe_pics_telebot/bot/inline.py
+++ b/src/cringe_pics_telebot/bot/inline.py
@@ -17,6 +17,7 @@ from cringe_pics_telebot.repositories.postgres import SubscriptionType
 from cringe_pics_telebot.services.category_aliases import normalize_category_search_term
 from cringe_pics_telebot.services.inline_images import (
     MAX_INLINE_QUERY_RESULTS,
+    get_inline_category_images,
     get_inline_images,
 )
 from cringe_pics_telebot.services.inline_metrics import (
@@ -29,6 +30,8 @@ from cringe_pics_telebot.services.inline_metrics import (
 )
 from cringe_pics_telebot.services.random_image import CachedMedia, LinkedMedia
 from cringe_pics_telebot.services.subscriptions import get_subscription_types
+
+from .keyboards import format_category_button_text
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +46,8 @@ router = Router(name="inline")
 
 @router.inline_query()
 async def answer_inline_query(inline_query: InlineQuery) -> None:
-    with InlineQueryMetrics.start(
-        query_is_empty=not bool(normalize_category_search_term(inline_query.query)),
-    ) as metrics:
+    query_is_empty = not bool(normalize_category_search_term(inline_query.query))
+    with InlineQueryMetrics.start(query_is_empty=query_is_empty) as metrics:
         subscription_types = await _find_subscription_types(inline_query.query)
         metrics.counts.matched_categories = len(subscription_types)
 
@@ -54,9 +56,13 @@ async def answer_inline_query(inline_query: InlineQuery) -> None:
             return
 
         try:
-            raw_results = await _get_inline_results(subscription_types)
+            raw_results = (
+                await _get_inline_category_results(subscription_types)
+                if query_is_empty
+                else await _get_inline_results(subscription_types)
+            )
             metrics.counts.results_prepared = len(raw_results)
-            results = _prepare_inline_results(raw_results)
+            results = raw_results if query_is_empty else _prepare_inline_results(raw_results)
         except Exception:
             metrics.set_outcome("handled_error")
             logger.exception("Failed to prepare inline results; correlation_id=%s", metrics.correlation_id)
@@ -71,15 +77,16 @@ async def answer_inline_query(inline_query: InlineQuery) -> None:
 
 @inline_query_stage(CATEGORIES_LOOKUP_STAGE)
 async def _find_subscription_types(query: str) -> list[SubscriptionType]:
-    if not normalize_category_search_term(query):
-        return []
-
     metrics = get_inline_query_metrics()
     if metrics is not None:
         metrics.counts.postgres_calls += 1
+    subscription_types = await get_subscription_types()
+    if not normalize_category_search_term(query):
+        return subscription_types
+
     return [
         subscription_type
-        for subscription_type in await get_subscription_types()
+        for subscription_type in subscription_types
         if category_matches_query(
             query,
             subscription_type.name,
@@ -104,6 +111,26 @@ def category_matches_query(query: str, category: str, search_aliases: Sequence[s
 async def _get_inline_results(subscription_types: list[SubscriptionType]) -> list[InlineMediaResult]:
     images = await get_inline_images(subscription_types)
     return _build_inline_results(images)
+
+
+async def _get_inline_category_results(subscription_types: list[SubscriptionType]) -> list[InlineMediaResult]:
+    images = await get_inline_category_images(subscription_types)
+    return _build_inline_category_results(images)
+
+
+@inline_query_stage(RESULTS_PREPARE_STAGE)
+def _build_inline_category_results(
+    images: list[tuple[SubscriptionType, CachedMedia | LinkedMedia]],
+) -> list[InlineMediaResult]:
+    return [
+        _inline_result(image, subscription_type=subscription_type).model_copy(
+            update={
+                "id": _category_result_id(subscription_type, image),
+                "title": f"🎲 {format_category_button_text(subscription_type)}",
+            }
+        )
+        for subscription_type, image in images
+    ]
 
 
 @inline_query_stage(RESULTS_PREPARE_STAGE)
@@ -163,6 +190,11 @@ def _prepare_inline_results(
 
 def _random_result_id(result_id: str) -> str:
     return hashlib.sha256(f"random:{result_id}".encode()).hexdigest()
+
+
+def _category_result_id(subscription_type: SubscriptionType, image: CachedMedia | LinkedMedia) -> str:
+    identity = f"category-random:{subscription_type.id}:{image.path}:{image.source_revision}"
+    return hashlib.sha256(identity.encode()).hexdigest()
 
 
 def _shuffle_inline_results(

--- a/src/cringe_pics_telebot/bot/keyboards.py
+++ b/src/cringe_pics_telebot/bot/keyboards.py
@@ -33,6 +33,10 @@ def create_inline_subscriptions_keyboard(
     return inline_keyboard_builder.as_markup()
 
 
+def format_category_button_text(subscription_type: SubscriptionType) -> str:
+    return subscription_type.name.capitalize()
+
+
 def create_reply_keyboard(
     subscription_types: Iterable[SubscriptionType],
     *,
@@ -45,7 +49,7 @@ def create_reply_keyboard(
     reply_keyboard_builder.button(text="Подписки")
 
     for subscription_type in sorted(subscription_types, key=lambda st: st.time):
-        reply_keyboard_builder.button(text=subscription_type.name.capitalize())
+        reply_keyboard_builder.button(text=format_category_button_text(subscription_type))
 
     reply_keyboard_builder.adjust(*(1, 1, 3) if is_admin else (1, 3))
     return reply_keyboard_builder.as_markup(

--- a/src/cringe_pics_telebot/services/inline_images.py
+++ b/src/cringe_pics_telebot/services/inline_images.py
@@ -19,6 +19,7 @@ from .inline_metrics import (
 
 MAX_INLINE_QUERY_RESULTS = 50
 
+type MediaChooser = Callable[[Sequence[CategoryMedia]], CategoryMedia]
 type MediaShuffler = Callable[[MutableSequence[CategoryMedia]], None]
 
 
@@ -29,36 +30,59 @@ async def get_inline_images(
     shuffler: MediaShuffler | None = None,
 ) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
     media = await _get_catalog_media([item.id for item in subscription_types])
-    metrics = get_inline_query_metrics()
-    if metrics is not None:
-        metrics.counts.catalog_media = len(media)
-
+    _record_catalog_media_count(media)
     selected_media = _select_inline_media(
         media,
         subscription_types=subscription_types,
         limit=limit,
         shuffler=shuffler,
     )
+    return await _resolve_inline_images(selected_media, subscription_types=subscription_types)
 
-    pending_paths = [item.source_path for item in selected_media if item.telegram_file_id is None]
-    if metrics is not None:
-        metrics.counts.selected_media = len(selected_media)
-        metrics.counts.ready_media = len(selected_media) - len(pending_paths)
-        metrics.counts.pending_media = len(pending_paths)
 
-    if pending_paths:
-        download_urls = await _get_media_urls(pending_paths)
-        if metrics is not None:
-            metrics.counts.url_successes += sum(url is not None for url in download_urls)
-            metrics.counts.url_failures += sum(url is None for url in download_urls)
-    else:
-        download_urls = []
-    download_urls_by_path = dict(zip(pending_paths, download_urls, strict=True))
-    return _prepare_inline_image_results(
-        selected_media,
+async def get_inline_category_images(
+    subscription_types: Sequence[SubscriptionType],
+    *,
+    limit: int = MAX_INLINE_QUERY_RESULTS,
+    chooser: MediaChooser | None = None,
+) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
+    media = await _get_catalog_media([item.id for item in subscription_types])
+    _record_catalog_media_count(media)
+    selected_media = _select_inline_category_media(
+        media,
         subscription_types=subscription_types,
-        download_urls_by_path=download_urls_by_path,
+        limit=limit,
+        chooser=chooser,
     )
+    return await _resolve_inline_images(selected_media, subscription_types=subscription_types)
+
+
+def _record_catalog_media_count(media: Sequence[CategoryMedia]) -> None:
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.catalog_media = len(media)
+
+
+def _select_inline_category_media(
+    media: Sequence[CategoryMedia],
+    *,
+    subscription_types: Sequence[SubscriptionType],
+    limit: int,
+    chooser: MediaChooser | None = None,
+) -> list[CategoryMedia]:
+    media_by_category: dict[int, list[CategoryMedia]] = {}
+    for item in media:
+        media_by_category.setdefault(item.subscription_type_id, []).append(item)
+
+    choose = chooser or random.choice
+    selected: list[CategoryMedia] = []
+    for subscription_type in subscription_types:
+        candidates = media_by_category.get(subscription_type.id, [])
+        ready = [item for item in candidates if item.telegram_file_id is not None]
+        if preferred := ready or candidates:
+            selected.append(choose(preferred))
+
+    return selected[:limit]
 
 
 def _select_inline_media(
@@ -87,6 +111,34 @@ def _select_inline_media(
 
     selected = [*ready, *pending]
     return selected if limit is None else selected[:limit]
+
+
+async def _resolve_inline_images(
+    selected_media: list[CategoryMedia],
+    *,
+    subscription_types: Sequence[SubscriptionType],
+) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
+    pending_media = [item for item in selected_media if item.telegram_file_id is None]
+    pending_paths = list(dict.fromkeys(item.source_path for item in pending_media))
+    metrics = get_inline_query_metrics()
+    if metrics is not None:
+        metrics.counts.selected_media = len(selected_media)
+        metrics.counts.ready_media = len(selected_media) - len(pending_media)
+        metrics.counts.pending_media = len(pending_media)
+
+    if pending_paths:
+        download_urls = await _get_media_urls(pending_paths)
+        if metrics is not None:
+            metrics.counts.url_successes += sum(url is not None for url in download_urls)
+            metrics.counts.url_failures += sum(url is None for url in download_urls)
+    else:
+        download_urls = []
+    download_urls_by_path = dict(zip(pending_paths, download_urls, strict=True))
+    return _prepare_inline_image_results(
+        selected_media,
+        subscription_types=subscription_types,
+        download_urls_by_path=download_urls_by_path,
+    )
 
 
 @inline_query_stage(MEDIA_CATALOG_STAGE)

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -4,6 +4,7 @@ from datetime import time
 from typing import Any
 
 import pytest
+from hamcrest import assert_that, equal_to, has_entries
 
 from cringe_pics_telebot.bot.subscription_callback_data import SubscriptionCallbackData
 from cringe_pics_telebot.services.media_sync import MediaSyncSummary
@@ -388,29 +389,121 @@ async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_p
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
 
 
-async def test_bot_records_empty_inline_query_without_database_lookup(
+async def test_bot_returns_random_media_per_category_for_empty_inline_query(
     bot_process: subprocess.Process,
     fake_statsd_server: FakeStatsDServer,
     fake_telegram_server: FakeTelegramServer,
+    fake_yandex_server: FakeYandexServer,
+    seed_functional_subscription_types: Callable[[tuple[FunctionalSubscriptionType, ...]], Awaitable[None]],
+    synchronize_functional_media_catalog: Callable[[], Awaitable[MediaSyncSummary]],
 ) -> None:
-    await fake_telegram_server.push_inline_query(query=" / ", query_id="inline-blank")
+    subscription_types = (
+        FunctionalSubscriptionType(1, "/ready-photo", time(0), "ready-photo"),
+        FunctionalSubscriptionType(2, "/pending-gif", time(1), "pending-gif"),
+        FunctionalSubscriptionType(3, "/pending-photo", time(2), "pending-photo"),
+        FunctionalSubscriptionType(4, "/empty", time(3), "empty"),
+        FunctionalSubscriptionType(5, "/broken", time(4), "broken"),
+    )
+    await seed_functional_subscription_types(subscription_types)
+    await fake_yandex_server.configure_directory("ready-photo", images=[{"name": "ready.png"}])
+    await fake_yandex_server.configure_directory(
+        "pending-gif",
+        images=[{"name": "pending.gif", "mime_type": "image/gif"}],
+    )
+    await fake_yandex_server.configure_directory("pending-photo", images=[{"name": "pending.png"}])
+    await fake_yandex_server.configure_directory("empty", images=[])
+    await fake_yandex_server.configure_directory(
+        "broken",
+        images=[{"name": "broken.gif", "mime_type": "image/gif"}],
+    )
+    await synchronize_functional_media_catalog()
 
+    await fake_telegram_server.push_message(text="/ready-photo")
+    await fake_telegram_server.wait_for_request("editMessageMedia")
+    await fake_telegram_server.reset()
+    await fake_yandex_server.reset()
+    await fake_statsd_server.reset()
+
+    await fake_telegram_server.push_inline_query(query=" / ", query_id="inline-blank")
     request = await fake_telegram_server.wait_for_request(
         "answerInlineQuery",
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-blank",
     )
-    assert request["payload"]["results"] == []
+
+    payload = request["payload"]
+    assert_that(payload["cache_time"], equal_to(0))
+    assert_that(payload["is_personal"], equal_to(True))
+    results = payload["results"]
+    assert_that(
+        [result["title"] for result in results],
+        equal_to(["🎲 /ready-photo", "🎲 /pending-gif", "🎲 /pending-photo"]),
+    )
+    results_by_title = {result["title"]: result for result in results}
+    assert_that(
+        results_by_title["🎲 /ready-photo"],
+        has_entries(type="photo", photo_file_id="functional-photo-file-id"),
+    )
+    assert_that(
+        results_by_title["🎲 /pending-gif"],
+        has_entries(
+            type="gif",
+            gif_url=f"{fake_yandex_server.base_url}/download/pending.gif",
+            thumbnail_url=f"{fake_yandex_server.base_url}/download/pending.gif",
+        ),
+    )
+    assert_that(
+        results_by_title["🎲 /pending-photo"],
+        has_entries(
+            type="photo",
+            photo_url=f"{fake_yandex_server.base_url}/download/pending.png",
+            thumbnail_url=f"{fake_yandex_server.base_url}/download/pending.png",
+        ),
+    )
+    result_ids = [result["id"] for result in results]
+    assert_that([len(result_id.encode()) for result_id in result_ids], equal_to([64, 64, 64]))
+    assert_that(len(set(result_ids)), equal_to(3))
+
+    yandex_requests = await fake_yandex_server.requests()
+    url_lookups = [request for request in yandex_requests if request["method"] == "resources/download"]
+    assert_that(
+        [request["params"]["path"] for request in url_lookups],
+        equal_to(
+            [
+                "app:/pending-gif/pending.gif",
+                "app:/pending-photo/pending.png",
+                "app:/broken/broken.gif",
+            ]
+        ),
+    )
+    assert_that([request for request in yandex_requests if request["method"] == "download"], equal_to([]))
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
+        "functional.inline.outcomes.partial_error.total",
         "functional.inline.scenarios.empty_query.total",
         "functional.inline.dependencies.postgres.calls",
         "functional.inline.dependencies.yandex.calls",
         "functional.inline.dependencies.telegram.calls",
+        "functional.inline.media.catalog_items",
+        "functional.inline.media.selected_items",
+        "functional.inline.media.ready_items",
+        "functional.inline.media.pending_items",
+        "functional.inline.media.url_successes",
+        "functional.inline.media.url_failures",
+        "functional.inline.results.prepared",
+        "functional.inline.results.sent",
     )
-    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 0
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
-    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
+    assert_that(metrics["functional.inline.dependencies.postgres.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(3))
+    assert_that(metrics["functional.inline.dependencies.telegram.calls"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.media.catalog_items"]["value"], equal_to(4))
+    assert_that(metrics["functional.inline.media.selected_items"]["value"], equal_to(4))
+    assert_that(metrics["functional.inline.media.ready_items"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.media.pending_items"]["value"], equal_to(3))
+    assert_that(metrics["functional.inline.media.url_successes"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.media.url_failures"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.results.prepared"]["value"], equal_to(3))
+    assert_that(metrics["functional.inline.results.sent"]["value"], equal_to(3))
 
 
 async def test_bot_returns_empty_inline_results_for_known_empty_category_and_keeps_polling(

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -14,9 +14,10 @@ from aiogram.types import (
     InlineQueryResultPhoto,
     InlineQueryResultUnion,
 )
+from hamcrest import assert_that, equal_to
 from pytest import MonkeyPatch
 
-from cringe_pics_telebot.bot import inline
+from cringe_pics_telebot.bot import inline, keyboards
 from cringe_pics_telebot.repositories.postgres import SubscriptionType
 from cringe_pics_telebot.services.random_image import CachedMedia, LinkedMedia
 
@@ -43,6 +44,20 @@ def test_category_matches_query(
     matches: bool,
 ) -> None:
     assert inline.category_matches_query(query, category, search_aliases) is matches
+
+
+@pytest.mark.parametrize("query", ["", "   ", " / "])
+async def test_find_subscription_types_returns_all_categories_for_normalized_empty_query(
+    monkeypatch: MonkeyPatch,
+    query: str,
+) -> None:
+    subscription_types = [
+        _subscription_type(1, "/morning", "morning"),
+        _subscription_type(2, "/day", "day"),
+    ]
+    monkeypatch.setattr(inline, "get_subscription_types", lambda: _async_result(subscription_types))
+
+    assert_that(await inline._find_subscription_types(query), equal_to(subscription_types))
 
 
 async def test_find_subscription_types_returns_every_matching_category(monkeypatch: MonkeyPatch) -> None:
@@ -121,6 +136,102 @@ async def test_get_inline_results_combines_categories_without_duplicate_paths(mo
     assert payloads[0]["description"] == "Категория /morning"
     assert payloads[2]["description"] == "Категория /evening"
     assert len({payload["id"] for payload in payloads}) == 3
+
+
+def test_build_inline_category_results_preserves_media_types_and_namespaces_category_ids() -> None:
+    categories = [
+        _subscription_type(1, "/morning", "morning"),
+        _subscription_type(2, "/day", "day"),
+        _subscription_type(3, "/evening", "evening"),
+        _subscription_type(4, "/night", "night"),
+    ]
+    images: list[tuple[SubscriptionType, CachedMedia | LinkedMedia]] = [
+        (
+            categories[0],
+            CachedMedia(
+                name="cached-photo.png",
+                mime_type="image/png",
+                path="shared/image.png",
+                source_revision="sha256:shared",
+                id="telegram-photo",
+            ),
+        ),
+        (
+            categories[1],
+            LinkedMedia(
+                name="linked-photo.png",
+                mime_type="image/png",
+                path="shared/image.png",
+                source_revision="sha256:shared",
+                url="https://storage.example/photo.png",
+            ),
+        ),
+        (
+            categories[2],
+            CachedMedia(
+                name="cached-animation.gif",
+                mime_type="image/gif",
+                path="evening/animation.gif",
+                source_revision="sha256:cached-animation",
+                id="telegram-animation",
+            ),
+        ),
+        (
+            categories[3],
+            LinkedMedia(
+                name="linked-animation.gif",
+                mime_type="image/gif",
+                path="night/animation.gif",
+                source_revision="sha256:linked-animation",
+                url="https://storage.example/animation.gif",
+            ),
+        ),
+    ]
+
+    results = inline._build_inline_category_results(images)
+    payloads = [result.model_dump(exclude_none=True) for result in results]
+
+    assert_that(
+        [type(result) for result in results],
+        equal_to(
+            [
+                InlineQueryResultCachedPhoto,
+                InlineQueryResultPhoto,
+                InlineQueryResultCachedGif,
+                InlineQueryResultGif,
+            ]
+        ),
+    )
+    assert_that(
+        [payload["title"] for payload in payloads],
+        equal_to([f"🎲 {keyboards.format_category_button_text(category)}" for category in categories]),
+    )
+    assert_that(
+        [
+            payloads[0]["photo_file_id"],
+            payloads[1]["photo_url"],
+            payloads[2]["gif_file_id"],
+            payloads[3]["gif_url"],
+        ],
+        equal_to(
+            [
+                "telegram-photo",
+                "https://storage.example/photo.png",
+                "telegram-animation",
+                "https://storage.example/animation.gif",
+            ]
+        ),
+    )
+    result_ids = [result.id for result in results]
+    assert_that([len(result_id) for result_id in result_ids], equal_to([64, 64, 64, 64]))
+    assert_that(len(set(result_ids)), equal_to(4))
+    assert_that(result_ids[0] == result_ids[1], equal_to(False))
+    assert_that(
+        set(result_ids).isdisjoint(
+            inline._inline_result(image, subscription_type=category).id for category, image in images
+        ),
+        equal_to(True),
+    )
 
 
 def test_shuffle_inline_results_uses_injected_shuffler_on_a_copy() -> None:
@@ -246,6 +357,43 @@ def test_prepare_inline_results_preserves_selected_media_type_and_source(result:
     assert prepared_result.id != result.id
 
 
+@pytest.mark.parametrize("query_text", ["", "   ", " / "])
+async def test_answer_inline_query_uses_category_results_for_normalized_empty_query(
+    monkeypatch: MonkeyPatch,
+    query_text: str,
+) -> None:
+    subscription_type = _subscription_type(2, "/day", "day")
+    category_results = _inline_results(2)
+    query = _FakeInlineQuery(query=query_text)
+
+    async def find_subscription_types(query: str) -> list[SubscriptionType]:
+        assert_that(query, equal_to(query_text))
+        return [subscription_type]
+
+    async def get_inline_category_results(
+        subscription_types: list[SubscriptionType],
+    ) -> list[inline.InlineMediaResult]:
+        assert_that(subscription_types, equal_to([subscription_type]))
+        return category_results
+
+    async def fail_get_inline_results(subscription_types: list[SubscriptionType]) -> list[inline.InlineMediaResult]:
+        raise AssertionError("ordinary inline results must not be loaded for an empty query")
+
+    def fail_prepare_inline_results(results: list[inline.InlineMediaResult]) -> list[inline.InlineMediaResult]:
+        raise AssertionError("category results must not receive the ordinary random result")
+
+    monkeypatch.setattr(inline, "_find_subscription_types", find_subscription_types)
+    monkeypatch.setattr(inline, "_get_inline_category_results", get_inline_category_results)
+    monkeypatch.setattr(inline, "_get_inline_results", fail_get_inline_results)
+    monkeypatch.setattr(inline, "_prepare_inline_results", fail_prepare_inline_results)
+
+    await inline.answer_inline_query(cast(InlineQuery, query))
+
+    assert_that(query.results, equal_to(category_results))
+    assert_that(query.cache_time, equal_to(0))
+    assert_that(query.is_personal, equal_to(True))
+
+
 async def test_answer_inline_query_prepares_results_and_disables_telegram_cache(monkeypatch: MonkeyPatch) -> None:
     subscription_type = _subscription_type(2, "/day", "day")
     results = _inline_results(inline.MAX_INLINE_QUERY_RESULTS + 1)
@@ -347,6 +495,10 @@ async def test_answer_inline_query_records_and_propagates_cancellation(
     event = _last_inline_metrics_event(caplog)
     assert event["outcome"] == "cancelled"
     assert event["counts"]["telegram_calls"] == 0
+
+
+async def _async_result[T](value: T) -> T:
+    return value
 
 
 def _inline_results(count: int) -> list[inline.InlineMediaResult]:

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -1,6 +1,7 @@
-from collections.abc import Iterable, MutableSequence
+from collections.abc import Iterable, MutableSequence, Sequence
 from datetime import UTC, datetime, time
 
+from hamcrest import assert_that, equal_to, has_properties, instance_of
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.repositories.postgres import (
@@ -238,6 +239,131 @@ async def test_get_inline_images_returns_empty_without_url_resolution(
     )
 
     assert await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order) == []
+
+
+async def test_get_inline_category_images_selects_one_per_nonempty_category_and_prefers_ready(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    morning = _subscription_type(1, name="/morning", directory="morning")
+    day = _subscription_type(2, name="/day", directory="day")
+    empty = _subscription_type(3, name="/empty", directory="empty")
+    media = [
+        _media(1, category_id=1, source_path="morning/1.png"),
+        _media(2, category_id=1, source_path="morning/2.png"),
+        _media(3, category_id=2, source_path="day/ready.png", file_id="telegram-ready"),
+        _media(4, category_id=2, source_path="day/pending.png"),
+    ]
+    chooser_inputs: list[list[int]] = []
+    requested_paths: list[str] = []
+
+    def choose_last(items: Sequence[CategoryMedia]) -> CategoryMedia:
+        chooser_inputs.append([item.id for item in items])
+        return items[-1]
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        requested_paths.extend(paths)
+        return [f"https://storage.example/{path}" for path in paths]
+
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result(media),
+    )
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    with InlineQueryMetrics.start(query_is_empty=True, clock=lambda: 1) as metrics:
+        results = await inline_images.get_inline_category_images(
+            [morning, day, empty],
+            chooser=choose_last,
+        )
+
+    assert_that(chooser_inputs, equal_to([[1, 2], [3]]))
+    assert_that(
+        [(category.id, image.path) for category, image in results],
+        equal_to([(1, "morning/2.png"), (2, "day/ready.png")]),
+    )
+    assert_that(results[0][1], instance_of(LinkedMedia))
+    assert_that(results[1][1], instance_of(CachedMedia))
+    assert_that(requested_paths, equal_to(["morning/2.png"]))
+    assert_that(
+        metrics.counts,
+        has_properties(
+            catalog_media=4,
+            selected_media=2,
+            ready_media=1,
+            pending_media=1,
+            url_successes=1,
+            url_failures=0,
+            postgres_calls=1,
+            yandex_calls=1,
+        ),
+    )
+
+
+async def test_get_inline_category_images_keeps_overlapping_paths_and_isolates_url_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    categories = [
+        _subscription_type(1, name="/morning", directory="morning"),
+        _subscription_type(2, name="/day", directory="day"),
+        _subscription_type(3, name="/evening", directory="evening"),
+    ]
+    media = [
+        _media(1, category_id=1, source_path="shared/image.png"),
+        _media(2, category_id=2, source_path="shared/image.png"),
+        _media(3, category_id=3, source_path="broken/image.png"),
+    ]
+    requested_paths: list[str] = []
+
+    async def get_urls(paths: Iterable[str]) -> list[str | None]:
+        requested_paths.extend(paths)
+        return ["https://storage.example/shared.png", None]
+
+    monkeypatch.setattr(
+        inline_images,
+        "get_category_media_by_subscription_types",
+        lambda category_ids: _async_result(media),
+    )
+    monkeypatch.setattr(inline_images, "get_download_urls", get_urls)
+
+    results = await inline_images.get_inline_category_images(categories, chooser=lambda items: items[0])
+
+    assert_that(requested_paths, equal_to(["shared/image.png", "broken/image.png"]))
+    assert_that(
+        [(category.id, image.path) for category, image in results],
+        equal_to([(1, "shared/image.png"), (2, "shared/image.png")]),
+    )
+    assert_that(results[0][1], instance_of(LinkedMedia))
+    assert_that(results[1][1], instance_of(LinkedMedia))
+
+
+def test_select_inline_category_media_chooses_before_stable_category_limit() -> None:
+    categories = [
+        _subscription_type(index, name=f"/category-{index}", directory=f"category-{index}") for index in range(1, 52)
+    ]
+    media = [
+        _media(
+            index,
+            category_id=index,
+            source_path=f"category-{index}/image.png",
+        )
+        for index in range(1, 52)
+    ]
+    chooser_inputs: list[list[int]] = []
+
+    def choose_only(items: Sequence[CategoryMedia]) -> CategoryMedia:
+        chooser_inputs.append([item.id for item in items])
+        return items[0]
+
+    selected = inline_images._select_inline_category_media(
+        media,
+        subscription_types=categories,
+        limit=inline_images.MAX_INLINE_QUERY_RESULTS,
+        chooser=choose_only,
+    )
+
+    assert_that(chooser_inputs, equal_to([[index] for index in range(1, 52)]))
+    assert_that([item.id for item in selected], equal_to(list(range(1, 51))))
 
 
 async def _async_result[T](value: T) -> T:


### PR DESCRIPTION
Closes #55

## Что сделано

- Пустой, пробельный и нормализующийся в пустой inline-запрос загружает актуальные категории из PostgreSQL.
- Для каждой непустой категории пакетно выбирается одно случайное активное медиа с приоритетом ready над pending.
- Выбор выполняется из полного набора категории до стабильного ограничения в 50 вариантов.
- Ready-медиа возвращается через cached photo/GIF без URL lookup; URL запрашивается только для выбранного pending-медиа.
- Ошибка URL одной категории не мешает результатам других категорий, CancelledError не проглатывается.
- Одинаковый source_path в разных категориях остаётся отдельным действием; ID учитывает категорию и медиа и занимает 64 байта.
- Title имеет формат 🎲 + название категории из reply-клавиатуры.
- Непустой известный и неизвестный inline flow сохранён без изменения семантики.
- Локальные каталоги планов .agents/plans и .codex/plans добавлены в .gitignore.

## Проверки

- uv run ruff check
- uv run ruff format --check
- uv run mypy .
- uv run pytest tests/units -q — 137 passed
- uv run pytest tests/functional -q — 50 passed, 1 skipped (non-gating latency baseline)
- Crit review каждого feature-коммита — approved
- Финальный Crit review ветки — approved

## UX / ручная проверка

Ручной smoke-test в Telegram Desktop и официальном мобильном клиенте не выполнялся по решению автора. Возможное отображение media results только галереей без заметного title принято как допустимое ограничение текущей итерации: по thumbnail самого медиа пользователь всё равно может понять, какой вариант будет отправлен. Механизм остаётся стандартным inline photo/GIF result и отправляет медиа, а не текст.