### PR TITLE
Migrate tests to PyHamcrest

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -15,6 +15,7 @@ import asyncpg
 import pytest
 import pytest_asyncio
 from aiogram import Bot
+from hamcrest import assert_that, empty, equal_to, greater_than_or_equal_to, is_, none
 from redis import asyncio as redis
 
 from cringe_pics_telebot.bot.bot import create_bot
@@ -1083,7 +1084,7 @@ async def _prepare_legacy_schema(dependency_ports: DependencyPorts) -> None:
 async def _assert_schema_migrated(dependency_ports: DependencyPorts) -> None:
     connection = await _create_postgres_connection(dependency_ports)
     try:
-        assert (
+        assert_that(
             await connection.fetchval(
                 """
                 SELECT data_type
@@ -1092,31 +1093,41 @@ async def _assert_schema_migrated(dependency_ports: DependencyPorts) -> None:
                   AND table_name = 'subscription_types'
                   AND column_name = 'time'
                 """
-            )
-            == "time without time zone"
+            ),
+            equal_to("time without time zone"),
         )
-        assert await connection.fetchval("SELECT time FROM subscription_types WHERE name = '/migration-probe'") == time(
-            10, 0
+        assert_that(
+            await connection.fetchval("SELECT time FROM subscription_types WHERE name = '/migration-probe'"),
+            equal_to(time(10, 0)),
         )
-        assert await connection.fetchval("SELECT timezone_offset_minutes FROM users WHERE id = 1") == 420
-        assert await connection.fetchval("SELECT is_active FROM users WHERE id = 1") is True
-        assert (
-            await connection.fetchval("SELECT search_aliases FROM subscription_types WHERE name = '/migration-probe'")
-            == []
+        assert_that(
+            await connection.fetchval("SELECT timezone_offset_minutes FROM users WHERE id = 1"),
+            equal_to(420),
         )
-        assert await connection.fetchval("SELECT to_regclass('administrators')") == "administrators"
-        assert await connection.fetchval("SELECT to_regclass('admin_broadcasts')") == "admin_broadcasts"
-        assert (
-            await connection.fetchval("SELECT to_regclass('admin_broadcast_recipients')")
-            == "admin_broadcast_recipients"
+        assert_that(await connection.fetchval("SELECT is_active FROM users WHERE id = 1"), is_(True))
+        assert_that(
+            await connection.fetchval("SELECT search_aliases FROM subscription_types WHERE name = '/migration-probe'"),
+            empty(),
         )
-        assert (
-            await connection.fetchval("SELECT to_regclass('admin_broadcast_deliveries')")
-            == "admin_broadcast_deliveries"
+        assert_that(await connection.fetchval("SELECT to_regclass('administrators')"), equal_to("administrators"))
+        assert_that(
+            await connection.fetchval("SELECT to_regclass('admin_broadcasts')"),
+            equal_to("admin_broadcasts"),
         )
-        assert int(await connection.fetchval("SHOW server_version_num")) >= 180000
-        assert await connection.fetchval("SELECT to_regclass('category_media')") == "category_media"
-        assert (
+        assert_that(
+            await connection.fetchval("SELECT to_regclass('admin_broadcast_recipients')"),
+            equal_to("admin_broadcast_recipients"),
+        )
+        assert_that(
+            await connection.fetchval("SELECT to_regclass('admin_broadcast_deliveries')"),
+            equal_to("admin_broadcast_deliveries"),
+        )
+        assert_that(int(await connection.fetchval("SHOW server_version_num")), greater_than_or_equal_to(180000))
+        assert_that(
+            await connection.fetchval("SELECT to_regclass('category_media')"),
+            equal_to("category_media"),
+        )
+        assert_that(
             await connection.fetchval(
                 """
                 SELECT attgenerated
@@ -1124,8 +1135,8 @@ async def _assert_schema_migrated(dependency_ports: DependencyPorts) -> None:
                 WHERE attrelid = 'category_media'::regclass
                   AND attname = 'status'
                 """
-            )
-            == b"v"
+            ),
+            equal_to(b"v"),
         )
     finally:
         await connection.close()
@@ -1134,8 +1145,11 @@ async def _assert_schema_migrated(dependency_ports: DependencyPorts) -> None:
 async def _assert_category_media_table_absent(dependency_ports: DependencyPorts) -> None:
     connection = await _create_postgres_connection(dependency_ports)
     try:
-        assert await connection.fetchval("SELECT to_regclass('category_media')") is None
-        assert await connection.fetchval("SELECT count(*) FROM subscription_types WHERE name = '/migration-probe'") == 1
+        assert_that(await connection.fetchval("SELECT to_regclass('category_media')"), none())
+        assert_that(
+            await connection.fetchval("SELECT count(*) FROM subscription_types WHERE name = '/migration-probe'"),
+            equal_to(1),
+        )
     finally:
         await connection.close()
 
@@ -1143,18 +1157,24 @@ async def _assert_category_media_table_absent(dependency_ports: DependencyPorts)
 async def _assert_category_aliases_column_absent(dependency_ports: DependencyPorts) -> None:
     connection = await _create_postgres_connection(dependency_ports)
     try:
-        assert not await connection.fetchval(
-            """
-            SELECT EXISTS (
-                SELECT 1
-                FROM information_schema.columns
-                WHERE table_schema = current_schema()
-                  AND table_name = 'subscription_types'
-                  AND column_name = 'search_aliases'
-            )
-            """
+        assert_that(
+            await connection.fetchval(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'subscription_types'
+                      AND column_name = 'search_aliases'
+                )
+                """
+            ),
+            is_(False),
         )
-        assert await connection.fetchval("SELECT count(*) FROM subscription_types WHERE name = '/migration-probe'") == 1
+        assert_that(
+            await connection.fetchval("SELECT count(*) FROM subscription_types WHERE name = '/migration-probe'"),
+            equal_to(1),
+        )
     finally:
         await connection.close()
 

--- a/tests/functional/test_admin_broadcasts.py
+++ b/tests/functional/test_admin_broadcasts.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import pytest
+from hamcrest import assert_that, empty, equal_to
 
 from tests.functional.conftest import FakeTelegramServer, FunctionalSubscriptionType
 
@@ -27,22 +28,25 @@ async def test_local_broadcast_sends_to_all_active_users_in_their_timezones_once
         scheduled_local_at=datetime(2026, 8, 17, 10, 0),
     )
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)) == 1
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, 30, tzinfo=UTC)) == 0
-    assert _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")) == [700]
-    assert await read_admin_broadcast_state(broadcast_id) == ("sending", [(700, "sent")])
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)), equal_to(1))
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, 30, tzinfo=UTC)), equal_to(0))
+    assert_that(_copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")), equal_to([700]))
+    assert_that(await read_admin_broadcast_state(broadcast_id), equal_to(("sending", [(700, "sent")])))
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 6, 0, tzinfo=UTC)) == 1
-    assert _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")) == [400, 700]
-    assert await read_admin_broadcast_state(broadcast_id) == (
-        "sending",
-        [(400, "sent"), (700, "sent")],
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 6, 0, tzinfo=UTC)), equal_to(1))
+    assert_that(
+        _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")),
+        equal_to([400, 700]),
+    )
+    assert_that(
+        await read_admin_broadcast_state(broadcast_id),
+        equal_to(("sending", [(400, "sent"), (700, "sent")])),
     )
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 22, 0, tzinfo=UTC)) == 0
-    assert await read_admin_broadcast_state(broadcast_id) == (
-        "completed",
-        [(400, "sent"), (700, "sent")],
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 22, 0, tzinfo=UTC)), equal_to(0))
+    assert_that(
+        await read_admin_broadcast_state(broadcast_id),
+        equal_to(("completed", [(400, "sent"), (700, "sent")])),
     )
 
 
@@ -60,14 +64,17 @@ async def test_timezone_override_sends_to_every_user_at_one_instant(
         timezone_offset_minutes=420,
     )
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 2, 59, tzinfo=UTC)) == 0
-    assert not await fake_telegram_server.requests(method="copyMessage")
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 2, 59, tzinfo=UTC)), equal_to(0))
+    assert_that(await fake_telegram_server.requests(method="copyMessage"), empty())
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)) == 2
-    assert _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")) == [400, 700]
-    assert await read_admin_broadcast_state(broadcast_id) == (
-        "completed",
-        [(400, "sent"), (700, "sent")],
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)), equal_to(2))
+    assert_that(
+        _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")),
+        equal_to([400, 700]),
+    )
+    assert_that(
+        await read_admin_broadcast_state(broadcast_id),
+        equal_to(("completed", [(400, "sent"), (700, "sent")])),
     )
 
 
@@ -87,13 +94,13 @@ async def test_forbidden_user_is_deactivated_without_losing_profile(
     )
     await fake_telegram_server.set_forbidden_chat_ids(700)
 
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)) == 1
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)), equal_to(1))
 
-    assert await read_user_state(700) == (-300, False)
-    assert await read_user_state(400) == (240, True)
-    assert await read_admin_broadcast_state(broadcast_id) == (
-        "completed",
-        [(400, "sent"), (700, "failed")],
+    assert_that(await read_user_state(700), equal_to((-300, False)))
+    assert_that(await read_user_state(400), equal_to((240, True)))
+    assert_that(
+        await read_admin_broadcast_state(broadcast_id),
+        equal_to(("completed", [(400, "sent"), (700, "failed")])),
     )
 
 
@@ -115,10 +122,13 @@ async def test_explicit_inactive_recipient_is_added_to_one_broadcast(
         user_ids=(900,),
     )
 
-    assert await read_user_state(900) == (420, False)
-    assert await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)) == 2
-    assert _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")) == [400, 900]
-    assert await read_user_state(900) == (420, False)
+    assert_that(await read_user_state(900), equal_to((420, False)))
+    assert_that(await run_admin_broadcasts_at(datetime(2026, 8, 17, 3, 0, tzinfo=UTC)), equal_to(2))
+    assert_that(
+        _copied_chat_ids(await fake_telegram_server.requests(method="copyMessage")),
+        equal_to([400, 900]),
+    )
+    assert_that(await read_user_state(900), equal_to((420, False)))
 
 
 def _copied_chat_ids(requests: list[dict[str, Any]]) -> list[int]:

--- a/tests/functional/test_admin_panel.py
+++ b/tests/functional/test_admin_panel.py
@@ -4,6 +4,17 @@ from datetime import datetime
 from typing import Any
 
 import pytest
+from hamcrest import (
+    assert_that,
+    contains_string,
+    empty,
+    equal_to,
+    greater_than,
+    has_entries,
+    has_item,
+    has_length,
+    none,
+)
 
 from cringe_pics_telebot.bot.admin_broadcast_callback_data import (
     AdminBroadcastAction,
@@ -39,14 +50,17 @@ async def test_admin_access_and_reply_button_follow_database_without_restart(
         "sendMessage",
         predicate=lambda request: "Что умеет бот" in request["payload"].get("text", ""),
     )
-    assert _reply_keyboard_button_texts(start_request["payload"])[0] == "Админ-панель"
+    assert_that(_reply_keyboard_button_texts(start_request["payload"])[0], equal_to("Админ-панель"))
 
     await fake_telegram_server.push_message(text="/admin")
     admin_panel = await fake_telegram_server.wait_for_request(
         "sendMessage",
         predicate=lambda request: "Админ-панель" in request["payload"].get("text", ""),
     )
-    assert _inline_keyboard_button_texts(admin_panel["payload"]) == ["Рассылки", "Управление категориями"]
+    assert_that(
+        _inline_keyboard_button_texts(admin_panel["payload"]),
+        equal_to(["Рассылки", "Управление категориями"]),
+    )
 
     await set_functional_administrator(user_id=42, enabled=False)
     await fake_telegram_server.reset()
@@ -55,7 +69,8 @@ async def test_admin_access_and_reply_button_follow_database_without_restart(
         "sendMessage",
         predicate=lambda request: "Что умеет бот" in request["payload"].get("text", ""),
     )
-    assert "Админ-панель" not in _reply_keyboard_button_texts(non_admin_request["payload"])
+    button_texts = _reply_keyboard_button_texts(non_admin_request["payload"])
+    assert_that([text for text in button_texts if text == "Админ-панель"], empty())
 
     await fake_telegram_server.reset()
     await fake_telegram_server.push_message(text="Админ-панель")
@@ -84,8 +99,8 @@ async def test_non_admin_cannot_forge_admin_callback(
         predicate=lambda request: request["payload"].get("chat_id") == 999,
     )
 
-    assert not await fake_telegram_server.requests(method="editMessageText")
-    assert not await fake_telegram_server.requests(method="answerCallbackQuery")
+    assert_that(await fake_telegram_server.requests(method="editMessageText"), empty())
+    assert_that(await fake_telegram_server.requests(method="answerCallbackQuery"), empty())
 
 
 async def test_admin_manages_category_aliases_used_by_inline_search(
@@ -107,14 +122,10 @@ async def test_admin_manages_category_aliases_used_by_inline_search(
         "editMessageText",
         predicate=lambda request: "Управление категориями" in request["payload"].get("text", ""),
     )
-    assert _inline_keyboard_button_texts(category_list["payload"]) == [
-        "/day",
-        "/evening",
-        "/morning",
-        "/night",
-        "/random",
-        "Назад",
-    ]
+    assert_that(
+        _inline_keyboard_button_texts(category_list["payload"]),
+        equal_to(["/day", "/evening", "/morning", "/night", "/random", "Назад"]),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_category_callback(AdminCategoryAction.category, category_id=2),
@@ -124,12 +135,11 @@ async def test_admin_manages_category_aliases_used_by_inline_search(
         "editMessageText",
         predicate=lambda request: "Категория /day" in request["payload"].get("text", ""),
     )
-    assert "<code>день</code>" in category_details["payload"]["text"]
-    assert _inline_keyboard_button_texts(category_details["payload"]) == [
-        "Изменить алиасы",
-        "Очистить алиасы",
-        "Назад",
-    ]
+    assert_that(category_details["payload"]["text"], contains_string("<code>день</code>"))
+    assert_that(
+        _inline_keyboard_button_texts(category_details["payload"]),
+        equal_to(["Изменить алиасы", "Очистить алиасы", "Назад"]),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_category_callback(AdminCategoryAction.edit_aliases, category_id=2),
@@ -150,16 +160,19 @@ async def test_admin_manages_category_aliases_used_by_inline_search(
         "sendMessage",
         predicate=lambda request: "Алиасы категории обновлены" in request["payload"].get("text", ""),
     )
-    assert "<code>полдень</code>" in updated_details["payload"]["text"]
-    assert await read_category_aliases(2) == ("полдень", "/ДЕНЬ", "с обеда")
+    assert_that(updated_details["payload"]["text"], contains_string("<code>полдень</code>"))
+    assert_that(await read_category_aliases(2), equal_to(("полдень", "/ДЕНЬ", "с обеда")))
 
     await fake_telegram_server.push_inline_query(query="  ПОЛД  ", query_id="inline-admin-alias")
     inline_answer = await fake_telegram_server.wait_for_request(
         "answerInlineQuery",
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-admin-alias",
     )
-    assert inline_answer["payload"]["results"]
-    assert {result["description"] for result in inline_answer["payload"]["results"]} == {"Категория /day"}
+    assert_that(len(inline_answer["payload"]["results"]), greater_than(0))
+    assert_that(
+        {result["description"] for result in inline_answer["payload"]["results"]},
+        equal_to({"Категория /day"}),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_category_callback(AdminCategoryAction.clear_aliases, category_id=2),
@@ -169,8 +182,11 @@ async def test_admin_manages_category_aliases_used_by_inline_search(
         "editMessageText",
         predicate=lambda request: "<i>не заданы</i>" in request["payload"].get("text", ""),
     )
-    assert _inline_keyboard_button_texts(cleared_details["payload"]) == ["Изменить алиасы", "Назад"]
-    assert await read_category_aliases(2) == ()
+    assert_that(
+        _inline_keyboard_button_texts(cleared_details["payload"]),
+        equal_to(["Изменить алиасы", "Назад"]),
+    )
+    assert_that(await read_category_aliases(2), equal_to(()))
 
 
 async def test_empty_broadcast_list_starts_creation_and_validates_schedule(
@@ -205,7 +221,7 @@ async def test_empty_broadcast_list_starts_creation_and_validates_schedule(
         "sendMessage",
         predicate=lambda request: "Не удалось распознать" in request["payload"].get("text", ""),
     )
-    assert not await read_admin_broadcasts()
+    assert_that(await read_admin_broadcasts(), empty())
 
     await fake_telegram_server.push_message(text="20.08.2099 10:00")
     await fake_telegram_server.wait_for_request(
@@ -219,17 +235,22 @@ async def test_empty_broadcast_list_starts_creation_and_validates_schedule(
     )
 
     broadcasts = await read_admin_broadcasts()
-    assert len(broadcasts) == 1
-    assert broadcasts[0]["created_by_user_id"] == 42
-    assert broadcasts[0]["source_chat_id"] == 42
-    assert broadcasts[0]["source_message_id"] == 1
-    assert broadcasts[0]["scheduled_local_at"] == datetime(2099, 8, 20, 10, 0)
-    assert broadcasts[0]["timezone_offset_minutes"] is None
-    assert broadcasts[0]["status"] == "scheduled"
-    assert await read_admin_broadcast_recipient_ids(broadcasts[0]["id"]) == [700, 800]
-    assert await read_user_state(700) == (420, False)
-    assert await read_user_state(800) == (420, False)
-    assert "Новая рассылка" in _inline_keyboard_button_texts(confirmation["payload"])
+    assert_that(broadcasts, has_length(1))
+    assert_that(
+        broadcasts[0],
+        has_entries(
+            created_by_user_id=42,
+            source_chat_id=42,
+            source_message_id=1,
+            scheduled_local_at=datetime(2099, 8, 20, 10, 0),
+            timezone_offset_minutes=none(),
+            status="scheduled",
+        ),
+    )
+    assert_that(await read_admin_broadcast_recipient_ids(broadcasts[0]["id"]), equal_to([700, 800]))
+    assert_that(await read_user_state(700), equal_to((420, False)))
+    assert_that(await read_user_state(800), equal_to((420, False)))
+    assert_that(_inline_keyboard_button_texts(confirmation["payload"]), has_item("Новая рассылка"))
 
 
 async def test_admin_edits_and_soft_deletes_existing_broadcast(
@@ -252,13 +273,10 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         "editMessageText",
         predicate=lambda request: "Запланированные рассылки" in request["payload"].get("text", ""),
     )
-    assert _inline_keyboard_button_texts(broadcast_list["payload"]) == [
-        "20.08 10:00 · локально",
-        "✏️",
-        "🗑",
-        "Новая рассылка",
-        "Назад",
-    ]
+    assert_that(
+        _inline_keyboard_button_texts(broadcast_list["payload"]),
+        equal_to(["20.08 10:00 · локально", "✏️", "🗑", "Новая рассылка", "Назад"]),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_broadcast_callback(AdminBroadcastAction.edit_broadcast, broadcast_id),
@@ -267,7 +285,7 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         "editMessageText",
         predicate=lambda request: "Рассылка #" in request["payload"].get("text", ""),
     )
-    assert "До отправки для вас: <b>" in broadcast_details["payload"]["text"]
+    assert_that(broadcast_details["payload"]["text"], contains_string("До отправки для вас: <b>"))
 
     await fake_telegram_server.push_callback_query(
         data=_admin_broadcast_callback(AdminBroadcastAction.edit_schedule, broadcast_id),
@@ -283,9 +301,10 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         predicate=lambda request: "Дата и время рассылки обновлены" in request["payload"].get("text", ""),
     )
     broadcast = await read_admin_broadcast(broadcast_id)
-    assert broadcast is not None
-    assert broadcast["scheduled_local_at"] == datetime(2099, 8, 21, 11, 30)
-    assert broadcast["timezone_offset_minutes"] == 240
+    assert_that(
+        [(item["scheduled_local_at"], item["timezone_offset_minutes"]) for item in [broadcast] if item is not None],
+        equal_to([(datetime(2099, 8, 21, 11, 30), 240)]),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_broadcast_callback(AdminBroadcastAction.edit_message, broadcast_id),
@@ -301,9 +320,10 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         predicate=lambda request: "Сообщение рассылки обновлено" in request["payload"].get("text", ""),
     )
     broadcast = await read_admin_broadcast(broadcast_id)
-    assert broadcast is not None
-    assert broadcast["source_chat_id"] == 42
-    assert broadcast["source_message_id"] == 1
+    assert_that(
+        [(item["source_chat_id"], item["source_message_id"]) for item in [broadcast] if item is not None],
+        equal_to([(42, 1)]),
+    )
 
     await fake_telegram_server.push_callback_query(
         data=_admin_broadcast_callback(AdminBroadcastAction.edit_recipients, broadcast_id),
@@ -318,7 +338,7 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         "sendMessage",
         predicate=lambda request: "Дополнительные получатели обновлены" in request["payload"].get("text", ""),
     )
-    assert await read_admin_broadcast_recipient_ids(broadcast_id) == [900, 901]
+    assert_that(await read_admin_broadcast_recipient_ids(broadcast_id), equal_to([900, 901]))
 
     await fake_telegram_server.push_callback_query(
         data=_admin_broadcast_callback(AdminBroadcastAction.delete_broadcast, broadcast_id),
@@ -337,9 +357,10 @@ async def test_admin_edits_and_soft_deletes_existing_broadcast(
         predicate=lambda request: request["payload"].get("text") == "Рассылка удалена.",
     )
     broadcast = await read_admin_broadcast(broadcast_id)
-    assert broadcast is not None
-    assert broadcast["status"] == "deleted"
-    assert broadcast["deleted_at"] is not None
+    assert_that(
+        [(item["status"], item["deleted_at"] is not None) for item in [broadcast] if item is not None],
+        equal_to([("deleted", True)]),
+    )
 
 
 async def test_admin_can_skip_explicit_recipients(
@@ -378,9 +399,9 @@ async def test_admin_can_skip_explicit_recipients(
     )
 
     broadcasts = await read_admin_broadcasts()
-    assert len(broadcasts) == 1
-    assert broadcasts[0]["created_by_user_id"] == 42
-    assert await read_admin_broadcast_recipient_ids(broadcasts[0]["id"]) == []
+    assert_that(broadcasts, has_length(1))
+    assert_that(broadcasts[0], has_entries(created_by_user_id=42))
+    assert_that(await read_admin_broadcast_recipient_ids(broadcasts[0]["id"]), empty())
 
 
 async def test_private_message_reactivates_user_without_resetting_timezone(
@@ -401,7 +422,7 @@ async def test_private_message_reactivates_user_without_resetting_timezone(
         predicate=lambda request: request["payload"].get("chat_id") == 700,
     )
 
-    assert await read_user_state(700) == (-300, True)
+    assert_that(await read_user_state(700), equal_to((-300, True)))
 
 
 def _admin_broadcast_callback(action: AdminBroadcastAction, broadcast_id: int = 0) -> str:

--- a/tests/functional/test_bot_polling.py
+++ b/tests/functional/test_bot_polling.py
@@ -4,7 +4,19 @@ from datetime import time
 from typing import Any
 
 import pytest
-from hamcrest import assert_that, equal_to, has_entries
+from hamcrest import (
+    assert_that,
+    contains_string,
+    empty,
+    equal_to,
+    has_entries,
+    has_item,
+    has_length,
+    is_,
+    is_in,
+    only_contains,
+    starts_with,
+)
 
 from cringe_pics_telebot.bot.subscription_callback_data import SubscriptionCallbackData
 from cringe_pics_telebot.services.media_sync import MediaSyncSummary
@@ -38,25 +50,24 @@ async def test_bot_shows_start_screen_for_entry_points(
     )
 
     payload = request["payload"]
-    assert payload["chat_id"] == 42
-    assert "Что умеет бот" in payload["text"]
-    assert "Danil" in payload["text"]
-    assert (
-        "<code>/random</code>, <code>/morning</code>, <code>/day</code>, <code>/evening</code>, <code>/night</code>"
-    ) in payload["text"]
-    assert "<code>/list</code> или <code>/subscriptions</code>" in payload["text"]
-    assert "<code>/timezone [+HH:MM]</code>" in payload["text"]
-    assert "UTC+07:00" in payload["text"]
-    assert "<code>@имя_бота</code>" in payload["text"]
-    assert "Первый результат 🎲" in payload["text"]
-    assert _reply_keyboard_button_texts(payload) == [
-        "Подписки",
-        "/random",
-        "/morning",
-        "/day",
-        "/evening",
-        "/night",
-    ]
+    assert_that(payload["chat_id"], equal_to(42))
+    assert_that(payload["text"], contains_string("Что умеет бот"))
+    assert_that(payload["text"], contains_string("Danil"))
+    assert_that(
+        payload["text"],
+        contains_string(
+            "<code>/random</code>, <code>/morning</code>, <code>/day</code>, <code>/evening</code>, <code>/night</code>"
+        ),
+    )
+    assert_that(payload["text"], contains_string("<code>/list</code> или <code>/subscriptions</code>"))
+    assert_that(payload["text"], contains_string("<code>/timezone [+HH:MM]</code>"))
+    assert_that(payload["text"], contains_string("UTC+07:00"))
+    assert_that(payload["text"], contains_string("<code>@имя_бота</code>"))
+    assert_that(payload["text"], contains_string("Первый результат 🎲"))
+    assert_that(
+        _reply_keyboard_button_texts(payload),
+        equal_to(["Подписки", "/random", "/morning", "/day", "/evening", "/night"]),
+    )
 
 
 @pytest.mark.parametrize("text", ["/list", "/subscriptions", "Подписки"])
@@ -74,16 +85,21 @@ async def test_bot_shows_subscription_list(
     )
 
     payload = request["payload"]
-    assert payload["chat_id"] == 42
-    assert "список" in payload["text"]
-    assert "UTC+07:00" in payload["text"]
-    assert _inline_keyboard_button_texts(payload) == [
-        "❌ /random – 00:00",
-        "❌ /morning – 08:00",
-        "❌ /day – 13:00",
-        "❌ /evening – 19:00",
-        "❌ /night – 23:00",
-    ]
+    assert_that(payload["chat_id"], equal_to(42))
+    assert_that(payload["text"], contains_string("список"))
+    assert_that(payload["text"], contains_string("UTC+07:00"))
+    assert_that(
+        _inline_keyboard_button_texts(payload),
+        equal_to(
+            [
+                "❌ /random – 00:00",
+                "❌ /morning – 08:00",
+                "❌ /day – 13:00",
+                "❌ /evening – 19:00",
+                "❌ /night – 23:00",
+            ]
+        ),
+    )
 
 
 async def test_bot_shows_default_timezone(
@@ -97,8 +113,8 @@ async def test_bot_shows_default_timezone(
         predicate=lambda request: "текущий часовой пояс" in request["payload"].get("text", ""),
     )
 
-    assert request["payload"]["chat_id"] == 42
-    assert "UTC+07:00" in request["payload"]["text"]
+    assert_that(request["payload"]["chat_id"], equal_to(42))
+    assert_that(request["payload"]["text"], contains_string("UTC+07:00"))
 
 
 async def test_bot_saves_timezone(
@@ -113,8 +129,8 @@ async def test_bot_saves_timezone(
         predicate=lambda request: "Часовой пояс сохранён" in request["payload"].get("text", ""),
     )
 
-    assert "UTC+04:00" in request["payload"]["text"]
-    assert await read_user_timezone_offset(42) == 240
+    assert_that(request["payload"]["text"], contains_string("UTC+04:00"))
+    assert_that(await read_user_timezone_offset(42), equal_to(240))
 
 
 async def test_bot_rejects_invalid_timezone_without_changing_saved_value(
@@ -134,9 +150,9 @@ async def test_bot_rejects_invalid_timezone_without_changing_saved_value(
         predicate=lambda request: "Не удалось распознать" in request["payload"].get("text", ""),
     )
 
-    assert "-12:00" in request["payload"]["text"]
-    assert "+14:00" in request["payload"]["text"]
-    assert await read_user_timezone_offset(42) == -330
+    assert_that(request["payload"]["text"], contains_string("-12:00"))
+    assert_that(request["payload"]["text"], contains_string("+14:00"))
+    assert_that(await read_user_timezone_offset(42), equal_to(-330))
 
 
 async def test_bot_subscribes_from_callback(
@@ -150,7 +166,7 @@ async def test_bot_subscribes_from_callback(
         "answerCallbackQuery",
         predicate=lambda request: request["payload"].get("text") == "Подписка оформлена!",
     )
-    assert subscribe_answer["payload"]["callback_query_id"] == "callback-100"
+    assert_that(subscribe_answer["payload"]["callback_query_id"], equal_to("callback-100"))
 
     subscribe_markup = await fake_telegram_server.wait_for_request(
         "editMessageReplyMarkup",
@@ -162,7 +178,7 @@ async def test_bot_subscribes_from_callback(
             )
         ),
     )
-    assert "✅ /morning – 08:00" in _inline_keyboard_button_texts(subscribe_markup["payload"])
+    assert_that(_inline_keyboard_button_texts(subscribe_markup["payload"]), has_item("✅ /morning – 08:00"))
 
 
 async def test_bot_unsubscribes_from_callback(
@@ -178,7 +194,7 @@ async def test_bot_unsubscribes_from_callback(
         "answerCallbackQuery",
         predicate=lambda request: request["payload"].get("text") == "Подписка удалена!",
     )
-    assert unsubscribe_answer["payload"]["callback_query_id"] == "callback-100"
+    assert_that(unsubscribe_answer["payload"]["callback_query_id"], equal_to("callback-100"))
 
     unsubscribe_markup = await fake_telegram_server.wait_for_request(
         "editMessageReplyMarkup",
@@ -190,7 +206,7 @@ async def test_bot_unsubscribes_from_callback(
             )
         ),
     )
-    assert "❌ /morning – 08:00" in _inline_keyboard_button_texts(unsubscribe_markup["payload"])
+    assert_that(_inline_keyboard_button_texts(unsubscribe_markup["payload"]), has_item("❌ /morning – 08:00"))
 
 
 @pytest.mark.parametrize("category_name", ["/morning", "/day", "/evening", "/night", "/random"])
@@ -210,17 +226,17 @@ async def test_bot_sends_image_for_subscription_category(
         "sendMessage",
         predicate=lambda request: request["payload"].get("text") == "<i>Выбираю картинку</i>",
     )
-    assert _reply_to_message_id(choosing_message["payload"]) == 1
+    assert_that(_reply_to_message_id(choosing_message["payload"]), equal_to(1))
 
     edit_media = await fake_telegram_server.wait_for_request("editMessageMedia")
-    assert edit_media["payload"]["chat_id"] == 42
-    assert edit_media["payload"]["media"]["type"] == "photo"
-    assert edit_media["payload"]["media"]["media"].startswith(fake_yandex_server.base_url)
+    assert_that(edit_media["payload"]["chat_id"], equal_to(42))
+    assert_that(edit_media["payload"]["media"]["type"], equal_to("photo"))
+    assert_that(edit_media["payload"]["media"]["media"], starts_with(fake_yandex_server.base_url))
 
-    yandex_requests = await fake_yandex_server.requests()
-    assert not any(request["method"] == "resources" for request in yandex_requests)
-    assert any(request["method"] == "resources/download" for request in yandex_requests)
-    assert not any(request["method"] == "download" for request in yandex_requests)
+    yandex_methods = [request["method"] for request in await fake_yandex_server.requests()]
+    assert_that([method for method in yandex_methods if method == "resources"], empty())
+    assert_that(yandex_methods, has_item("resources/download"))
+    assert_that([method for method in yandex_methods if method == "download"], empty())
 
 
 async def test_bot_prefers_pending_media_over_ready_for_ordinary_delivery(
@@ -244,13 +260,24 @@ async def test_bot_prefers_pending_media_over_ready_for_ordinary_delivery(
     await fake_telegram_server.push_message(text="/day")
     edit_media = await fake_telegram_server.wait_for_request("editMessageMedia")
 
-    assert edit_media["payload"]["media"]["media"] == (f"{fake_yandex_server.base_url}/download/pending.png")
-    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
+    assert_that(
+        edit_media["payload"]["media"]["media"],
+        equal_to(f"{fake_yandex_server.base_url}/download/pending.png"),
+    )
+    assert_that(
+        sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()),
+        equal_to(1),
+    )
     states = await read_functional_category_media_states()
-    assert {path: state for path, state in states.items() if path.startswith("day/")} == {
-        "day/pending.png": ("ready", "functional-photo-file-id"),
-        "day/ready.png": ("ready", "functional-ready-file-id"),
-    }
+    assert_that(
+        {path: state for path, state in states.items() if path.startswith("day/")},
+        equal_to(
+            {
+                "day/pending.png": ("ready", "functional-photo-file-id"),
+                "day/ready.png": ("ready", "functional-ready-file-id"),
+            }
+        ),
+    )
 
 
 async def test_bot_recovers_invalid_catalog_file_id_once(
@@ -266,7 +293,7 @@ async def test_bot_recovers_invalid_catalog_file_id_once(
 
     await fake_telegram_server.push_message(text="/day")
     first_edit = await fake_telegram_server.wait_for_request("editMessageMedia")
-    assert first_edit["payload"]["media"]["media"].startswith(fake_yandex_server.base_url)
+    assert_that(first_edit["payload"]["media"]["media"], starts_with(fake_yandex_server.base_url))
 
     await fake_telegram_server.reset()
     await fake_telegram_server.set_invalid_file_ids("functional-photo-file-id")
@@ -276,14 +303,22 @@ async def test_bot_recovers_invalid_catalog_file_id_once(
         "editMessageMedia",
         predicate=lambda request: str(request["payload"]["media"]["media"]).startswith(fake_yandex_server.base_url),
     )
-    assert recovered_edit["payload"]["media"]["media"].startswith(fake_yandex_server.base_url)
+    assert_that(recovered_edit["payload"]["media"]["media"], starts_with(fake_yandex_server.base_url))
 
     edits = await fake_telegram_server.requests(method="editMessageMedia")
-    assert [request["payload"]["media"]["media"] for request in edits] == [
-        "functional-photo-file-id",
-        f"{fake_yandex_server.base_url}/download/image.png",
-    ]
-    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
+    assert_that(
+        [request["payload"]["media"]["media"] for request in edits],
+        equal_to(
+            [
+                "functional-photo-file-id",
+                f"{fake_yandex_server.base_url}/download/image.png",
+            ]
+        ),
+    )
+    assert_that(
+        sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()),
+        equal_to(1),
+    )
 
 
 @pytest.mark.parametrize("query", ["  dA ", "  ДНЕ "])
@@ -303,35 +338,56 @@ async def test_bot_returns_day_images_for_partial_inline_query(
     request = await fake_telegram_server.wait_for_request("answerInlineQuery")
 
     payload = request["payload"]
-    assert payload["inline_query_id"] == "inline-100"
-    assert payload["cache_time"] == 0
-    assert payload["is_personal"] is True
-    assert len(payload["results"]) == 2
+    assert_that(payload["inline_query_id"], equal_to("inline-100"))
+    assert_that(payload["cache_time"], equal_to(0))
+    assert_that(payload["is_personal"], is_(True))
+    assert_that(payload["results"], has_length(2))
     random_result, ordinary_result = payload["results"]
-    assert random_result["type"] == ordinary_result["type"] == "photo"
-    assert random_result["title"] == "🎲 Выбрать случайную картинку"
-    assert ordinary_result["title"] in {"image.png", "second.png"}
-    assert random_result["description"] == ordinary_result["description"] == "Категория /day"
-    assert random_result["thumbnail_url"] == random_result["photo_url"]
-    assert ordinary_result["thumbnail_url"] == ordinary_result["photo_url"]
-    assert {random_result["photo_url"], ordinary_result["photo_url"]} == {
-        f"{fake_yandex_server.base_url}/download/image.png",
-        f"{fake_yandex_server.base_url}/download/second.png",
-    }
-    assert len({random_result["id"], ordinary_result["id"]}) == 2
-    assert all(len(result["id"]) == 64 for result in payload["results"])
+    assert_that((random_result["type"], ordinary_result["type"]), equal_to(("photo", "photo")))
+    assert_that(random_result["title"], equal_to("🎲 Выбрать случайную картинку"))
+    assert_that(ordinary_result["title"], is_in(("image.png", "second.png")))
+    assert_that(
+        (random_result["description"], ordinary_result["description"]),
+        equal_to(("Категория /day", "Категория /day")),
+    )
+    assert_that(
+        (random_result["thumbnail_url"], ordinary_result["thumbnail_url"]),
+        equal_to((random_result["photo_url"], ordinary_result["photo_url"])),
+    )
+    assert_that(
+        {random_result["photo_url"], ordinary_result["photo_url"]},
+        equal_to(
+            {
+                f"{fake_yandex_server.base_url}/download/image.png",
+                f"{fake_yandex_server.base_url}/download/second.png",
+            }
+        ),
+    )
+    assert_that({random_result["id"], ordinary_result["id"]}, has_length(2))
+    assert_that([len(result["id"]) for result in payload["results"]], only_contains(64))
 
     yandex_requests = await fake_yandex_server.requests()
-    assert not any(request["method"] == "resources" for request in yandex_requests)
-    assert {
-        "method": "resources/download",
-        "params": {"path": "app:/day/image.png", "fields": "href"},
-    } in yandex_requests
-    assert {
-        "method": "resources/download",
-        "params": {"path": "app:/day/second.png", "fields": "href"},
-    } in yandex_requests
-    assert not any(request["method"] == "download" for request in yandex_requests)
+    yandex_methods = [request["method"] for request in yandex_requests]
+    assert_that([method for method in yandex_methods if method == "resources"], empty())
+    assert_that(
+        yandex_requests,
+        has_item(
+            {
+                "method": "resources/download",
+                "params": {"path": "app:/day/image.png", "fields": "href"},
+            }
+        ),
+    )
+    assert_that(
+        yandex_requests,
+        has_item(
+            {
+                "method": "resources/download",
+                "params": {"path": "app:/day/second.png", "fields": "href"},
+            }
+        ),
+    )
+    assert_that([method for method in yandex_methods if method == "download"], empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -348,13 +404,16 @@ async def test_bot_returns_day_images_for_partial_inline_query(
         "functional.inline.media.catalog_items",
         "functional.inline.results.sent",
     )
-    assert all(metrics[name]["type"] == "ms" for name in metrics if ".total" in name or ".stages." in name)
-    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 2
-    assert metrics["functional.inline.dependencies.redis.calls"]["value"] == 0
-    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
-    assert metrics["functional.inline.media.catalog_items"]["value"] == 2
-    assert metrics["functional.inline.results.sent"]["value"] == 2
+    assert_that(
+        all(metrics[name]["type"] == "ms" for name in metrics if ".total" in name or ".stages." in name),
+        is_(True),
+    )
+    assert_that(metrics["functional.inline.dependencies.postgres.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.dependencies.redis.calls"]["value"], equal_to(0))
+    assert_that(metrics["functional.inline.dependencies.telegram.calls"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.media.catalog_items"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.results.sent"]["value"], equal_to(2))
 
 
 async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_polling(
@@ -369,7 +428,7 @@ async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_p
         "answerInlineQuery",
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-unknown",
     )
-    assert request["payload"]["results"] == []
+    assert_that(request["payload"]["results"], empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -379,11 +438,11 @@ async def test_bot_returns_empty_inline_results_for_unknown_category_and_keeps_p
         "functional.inline.dependencies.redis.calls",
         "functional.inline.dependencies.telegram.calls",
     )
-    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 1
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
-    assert metrics["functional.inline.dependencies.redis.calls"]["value"] == 0
-    assert metrics["functional.inline.dependencies.telegram.calls"]["value"] == 1
-    assert not await fake_statsd_server.metrics(name="functional.inline.stages.media.catalog")
+    assert_that(metrics["functional.inline.dependencies.postgres.calls"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(0))
+    assert_that(metrics["functional.inline.dependencies.redis.calls"]["value"], equal_to(0))
+    assert_that(metrics["functional.inline.dependencies.telegram.calls"]["value"], equal_to(1))
+    assert_that(await fake_statsd_server.metrics(name="functional.inline.stages.media.catalog"), empty())
 
     await fake_telegram_server.push_message(text="still running")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
@@ -523,7 +582,7 @@ async def test_bot_returns_empty_inline_results_for_known_empty_category_and_kee
         "answerInlineQuery",
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-empty",
     )
-    assert request["payload"]["results"] == []
+    assert_that(request["payload"]["results"], empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -532,9 +591,9 @@ async def test_bot_returns_empty_inline_results_for_known_empty_category_and_kee
         "functional.inline.dependencies.postgres.calls",
         "functional.inline.dependencies.yandex.calls",
     )
-    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
-    assert not await fake_statsd_server.metrics(name="functional.inline.stages.media.urls")
+    assert_that(metrics["functional.inline.dependencies.postgres.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(0))
+    assert_that(await fake_statsd_server.metrics(name="functional.inline.stages.media.urls"), empty())
 
     await fake_telegram_server.push_message(text="still running after empty inline category")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
@@ -557,7 +616,7 @@ async def test_bot_returns_empty_inline_results_when_image_url_fails_and_keeps_p
         "answerInlineQuery",
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-broken",
     )
-    assert request["payload"]["results"] == []
+    assert_that(request["payload"]["results"], empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -566,8 +625,8 @@ async def test_bot_returns_empty_inline_results_when_image_url_fails_and_keeps_p
         "functional.inline.media.url_failures",
         "functional.inline.results.sent",
     )
-    assert metrics["functional.inline.media.url_failures"]["value"] == 1
-    assert metrics["functional.inline.results.sent"]["value"] == 0
+    assert_that(metrics["functional.inline.media.url_failures"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.results.sent"]["value"], equal_to(0))
 
     await fake_telegram_server.push_message(text="still running after Yandex failure")
     await fake_telegram_server.wait_for_request("sendMessage", predicate=_is_start_answer)
@@ -596,12 +655,11 @@ async def test_inline_uses_persisted_file_id_after_ordinary_delivery(
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-ready",
     )
 
-    assert len(answer["payload"]["results"]) == 1
+    assert_that(answer["payload"]["results"], has_length(1))
     result = answer["payload"]["results"][0]
-    assert result["type"] == "photo"
-    assert result["photo_file_id"] == "functional-photo-file-id"
-    assert "photo_url" not in result
-    assert not await fake_yandex_server.requests()
+    assert_that(result, has_entries(type="photo", photo_file_id="functional-photo-file-id"))
+    assert_that([key for key in result if key == "photo_url"], empty())
+    assert_that(await fake_yandex_server.requests(), empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -610,9 +668,9 @@ async def test_inline_uses_persisted_file_id_after_ordinary_delivery(
         "functional.inline.media.pending_items",
         "functional.inline.dependencies.yandex.calls",
     )
-    assert metrics["functional.inline.media.ready_items"]["value"] == 1
-    assert metrics["functional.inline.media.pending_items"]["value"] == 0
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+    assert_that(metrics["functional.inline.media.ready_items"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.media.pending_items"]["value"], equal_to(0))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(0))
 
 
 async def test_inline_metrics_cover_mixed_ready_and_pending_media(
@@ -642,7 +700,7 @@ async def test_inline_metrics_cover_mixed_ready_and_pending_media(
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-mixed",
     )
 
-    assert len(answer["payload"]["results"]) == 2
+    assert_that(answer["payload"]["results"], has_length(2))
     metrics = await _wait_for_metrics(
         fake_statsd_server,
         "functional.inline.scenarios.mixed.total",
@@ -650,9 +708,9 @@ async def test_inline_metrics_cover_mixed_ready_and_pending_media(
         "functional.inline.media.pending_items",
         "functional.inline.dependencies.yandex.calls",
     )
-    assert metrics["functional.inline.media.ready_items"]["value"] == 1
-    assert metrics["functional.inline.media.pending_items"]["value"] == 1
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 1
+    assert_that(metrics["functional.inline.media.ready_items"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.media.pending_items"]["value"], equal_to(1))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(1))
 
 
 async def test_inline_metrics_cover_multiple_categories(
@@ -680,7 +738,7 @@ async def test_inline_metrics_cover_multiple_categories(
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-multiple",
     )
 
-    assert len(answer["payload"]["results"]) == 2
+    assert_that(answer["payload"]["results"], has_length(2))
     metrics = await _wait_for_metrics(
         fake_statsd_server,
         "functional.inline.category_sets.multiple.total",
@@ -688,9 +746,9 @@ async def test_inline_metrics_cover_multiple_categories(
         "functional.inline.dependencies.yandex.calls",
         "functional.inline.media.catalog_items",
     )
-    assert metrics["functional.inline.dependencies.postgres.calls"]["value"] == 2
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 2
-    assert metrics["functional.inline.media.catalog_items"]["value"] == 2
+    assert_that(metrics["functional.inline.dependencies.postgres.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(2))
+    assert_that(metrics["functional.inline.media.catalog_items"]["value"], equal_to(2))
 
 
 async def test_inline_metrics_cover_large_catalog_and_telegram_limit(
@@ -716,7 +774,7 @@ async def test_inline_metrics_cover_large_catalog_and_telegram_limit(
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-large",
     )
 
-    assert len(answer["payload"]["results"]) == 50
+    assert_that(answer["payload"]["results"], has_length(50))
     metrics = await _wait_for_metrics(
         fake_statsd_server,
         "functional.inline.catalog_sizes.large.total",
@@ -725,10 +783,10 @@ async def test_inline_metrics_cover_large_catalog_and_telegram_limit(
         "functional.inline.results.prepared",
         "functional.inline.results.sent",
     )
-    assert metrics["functional.inline.media.catalog_items"]["value"] == 60
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 50
-    assert metrics["functional.inline.results.prepared"]["value"] == 50
-    assert metrics["functional.inline.results.sent"]["value"] == 50
+    assert_that(metrics["functional.inline.media.catalog_items"]["value"], equal_to(60))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(50))
+    assert_that(metrics["functional.inline.results.prepared"]["value"], equal_to(50))
+    assert_that(metrics["functional.inline.results.sent"]["value"], equal_to(50))
 
 
 async def test_inline_uses_ready_media_to_fill_limit_without_pending_urls(
@@ -760,10 +818,13 @@ async def test_inline_uses_ready_media_to_fill_limit_without_pending_urls(
     )
 
     results = answer["payload"]["results"]
-    assert len(results) == 50
-    assert results[0]["title"] == "🎲 Выбрать случайную картинку"
-    assert all("photo_file_id" in result and "photo_url" not in result for result in results)
-    assert not await fake_yandex_server.requests()
+    assert_that(results, has_length(50))
+    assert_that(results[0]["title"], equal_to("🎲 Выбрать случайную картинку"))
+    assert_that(
+        ["photo_file_id" in result and "photo_url" not in result for result in results],
+        only_contains(True),
+    )
+    assert_that(await fake_yandex_server.requests(), empty())
 
     metrics = await _wait_for_metrics(
         fake_statsd_server,
@@ -772,10 +833,10 @@ async def test_inline_uses_ready_media_to_fill_limit_without_pending_urls(
         "functional.inline.media.pending_items",
         "functional.inline.dependencies.yandex.calls",
     )
-    assert metrics["functional.inline.media.catalog_items"]["value"] == 51
-    assert metrics["functional.inline.media.ready_items"]["value"] == 50
-    assert metrics["functional.inline.media.pending_items"]["value"] == 0
-    assert metrics["functional.inline.dependencies.yandex.calls"]["value"] == 0
+    assert_that(metrics["functional.inline.media.catalog_items"]["value"], equal_to(51))
+    assert_that(metrics["functional.inline.media.ready_items"]["value"], equal_to(50))
+    assert_that(metrics["functional.inline.media.pending_items"]["value"], equal_to(0))
+    assert_that(metrics["functional.inline.dependencies.yandex.calls"]["value"], equal_to(0))
 
 
 async def test_inline_excludes_media_deactivated_by_later_sync(
@@ -800,11 +861,14 @@ async def test_inline_excludes_media_deactivated_by_later_sync(
         predicate=lambda request: request["payload"].get("inline_query_id") == "inline-active-only",
     )
 
-    assert len(answer["payload"]["results"]) == 1
-    assert answer["payload"]["results"][0]["photo_url"] == f"{fake_yandex_server.base_url}/download/image.png"
+    assert_that(answer["payload"]["results"], has_length(1))
+    assert_that(
+        answer["payload"]["results"][0]["photo_url"],
+        equal_to(f"{fake_yandex_server.base_url}/download/image.png"),
+    )
     requests = await fake_yandex_server.requests()
-    assert sum(request["method"] == "resources/download" for request in requests) == 1
-    assert not any("removed.png" in str(request) for request in requests)
+    assert_that(sum(request["method"] == "resources/download" for request in requests), equal_to(1))
+    assert_that([request for request in requests if "removed.png" in str(request)], empty())
 
 
 def _is_start_answer(request: dict[str, Any]) -> bool:

--- a/tests/functional/test_category_media_repository.py
+++ b/tests/functional/test_category_media_repository.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, time
 
 import pytest
+from hamcrest import assert_that, empty, equal_to, none, not_none, same_instance
 
 from cringe_pics_telebot.repositories.postgres import (
     CategoryMediaSource,
@@ -41,12 +42,15 @@ async def test_reconcile_materialize_and_replace_revision(docker_compose: Depend
             sources=[source],
             seen_at=first_seen,
         )
-        assert result.discovered == result.created == 1
-        assert result.changed == result.reactivated == result.deactivated == result.unchanged == 0
+        assert_that((result.discovered, result.created), equal_to((1, 1)))
+        assert_that(
+            (result.changed, result.reactivated, result.deactivated, result.unchanged),
+            equal_to((0, 0, 0, 0)),
+        )
 
         media, *_ = await get_category_media_by_subscription_types([1])
-        assert media.status is CategoryMediaStatus.pending
-        assert media.last_seen_at == first_seen
+        assert_that(media.status, same_instance(CategoryMediaStatus.pending))
+        assert_that(media.last_seen_at, equal_to(first_seen))
 
         async with transaction():
             materialized = await materialize_category_media(
@@ -56,32 +60,37 @@ async def test_reconcile_materialize_and_replace_revision(docker_compose: Depend
                 telegram_file_unique_id="telegram-unique-id",
                 materialized_at=materialized_at,
             )
-        assert materialized is not None
-        assert materialized.status is CategoryMediaStatus.ready
+        assert_that(
+            [item.status for item in [materialized] if item is not None],
+            equal_to([CategoryMediaStatus.ready]),
+        )
 
         unchanged = await reconcile_category_media_snapshot(
             subscription_type_id=1,
             sources=[source],
             seen_at=second_seen,
         )
-        assert unchanged.unchanged == 1
+        assert_that(unchanged.unchanged, equal_to(1))
         ready, *_ = await get_category_media_by_subscription_types([1], ready_only=True)
-        assert ready.telegram_file_id == "telegram-file-id"
-        assert ready.last_seen_at == second_seen
-        assert ready.updated_at == materialized_at
+        assert_that(ready.telegram_file_id, equal_to("telegram-file-id"))
+        assert_that(ready.last_seen_at, equal_to(second_seen))
+        assert_that(ready.updated_at, equal_to(materialized_at))
 
         changed = await reconcile_category_media_snapshot(
             subscription_type_id=1,
             sources=[_source(source.source_path, revision="sha256:second")],
             seen_at=datetime(2026, 8, 19, 4, tzinfo=UTC),
         )
-        assert changed.changed == 1
+        assert_that(changed.changed, equal_to(1))
         pending = await get_category_media(media.id)
-        assert pending is not None
-        assert pending.status is CategoryMediaStatus.pending
-        assert pending.telegram_file_id is None
-        assert pending.telegram_file_unique_id is None
-        assert pending.materialized_at is None
+        assert_that(
+            [
+                (item.status, item.telegram_file_id, item.telegram_file_unique_id, item.materialized_at)
+                for item in [pending]
+                if item is not None
+            ],
+            equal_to([(CategoryMediaStatus.pending, None, None, None)]),
+        )
 
 
 async def test_deactivate_and_reactivate_same_revision_preserves_file_id(
@@ -93,27 +102,31 @@ async def test_deactivate_and_reactivate_same_revision_preserves_file_id(
         await reconcile_category_media_snapshot(subscription_type_id=1, sources=[source])
         media, *_ = await get_category_media_by_subscription_types([1])
         async with transaction():
-            assert await materialize_category_media(
-                media_id=media.id,
-                source_revision=source.source_revision,
-                telegram_file_id="telegram-file-id",
-                telegram_file_unique_id="telegram-unique-id",
+            assert_that(
+                await materialize_category_media(
+                    media_id=media.id,
+                    source_revision=source.source_revision,
+                    telegram_file_id="telegram-file-id",
+                    telegram_file_unique_id="telegram-unique-id",
+                ),
+                not_none(),
             )
 
         removed = await reconcile_category_media_snapshot(subscription_type_id=1, sources=[])
-        assert removed.deactivated == 1
-        assert await get_category_media_by_subscription_types([1]) == []
+        assert_that(removed.deactivated, equal_to(1))
+        assert_that(await get_category_media_by_subscription_types([1]), empty())
         inactive = await get_category_media(media.id)
-        assert inactive is not None
-        assert inactive.status is CategoryMediaStatus.inactive
-        assert inactive.telegram_file_id == "telegram-file-id"
+        assert_that(
+            [(item.status, item.telegram_file_id) for item in [inactive] if item is not None],
+            equal_to([(CategoryMediaStatus.inactive, "telegram-file-id")]),
+        )
 
         restored = await reconcile_category_media_snapshot(subscription_type_id=1, sources=[source])
-        assert restored.reactivated == 1
+        assert_that(restored.reactivated, equal_to(1))
         ready, *_ = await get_category_media_by_subscription_types([1], ready_only=True)
-        assert ready.id == media.id
-        assert ready.status is CategoryMediaStatus.ready
-        assert ready.telegram_file_id == "telegram-file-id"
+        assert_that(ready.id, equal_to(media.id))
+        assert_that(ready.status, same_instance(CategoryMediaStatus.ready))
+        assert_that(ready.telegram_file_id, equal_to("telegram-file-id"))
 
 
 async def test_materialize_and_invalidate_are_conditional(docker_compose: DependencyPorts) -> None:
@@ -124,29 +137,32 @@ async def test_materialize_and_invalidate_are_conditional(docker_compose: Depend
         media, *_ = await get_category_media_by_subscription_types([1])
 
         async with transaction():
-            assert (
+            assert_that(
                 await materialize_category_media(
                     media_id=media.id,
                     source_revision="sha256:stale",
                     telegram_file_id="telegram-file-id",
                     telegram_file_unique_id="telegram-unique-id",
-                )
-                is None
+                ),
+                none(),
             )
         async with transaction():
-            assert await materialize_category_media(
-                media_id=media.id,
-                source_revision=source.source_revision,
-                telegram_file_id="telegram-file-id",
-                telegram_file_unique_id="telegram-unique-id",
+            assert_that(
+                await materialize_category_media(
+                    media_id=media.id,
+                    source_revision=source.source_revision,
+                    telegram_file_id="telegram-file-id",
+                    telegram_file_unique_id="telegram-unique-id",
+                ),
+                not_none(),
             )
         async with transaction():
-            assert (
+            assert_that(
                 await invalidate_category_media_file_id(
                     media_id=media.id,
                     telegram_file_id="stale-file-id",
-                )
-                is None
+                ),
+                none(),
             )
 
         async with transaction():
@@ -154,8 +170,10 @@ async def test_materialize_and_invalidate_are_conditional(docker_compose: Depend
                 media_id=media.id,
                 telegram_file_id="telegram-file-id",
             )
-        assert invalidated is not None
-        assert invalidated.status is CategoryMediaStatus.pending
+        assert_that(
+            [item.status for item in [invalidated] if item is not None],
+            equal_to([CategoryMediaStatus.pending]),
+        )
 
 
 async def test_reconcile_deduplicates_source_paths(docker_compose: DependencyPorts) -> None:
@@ -166,9 +184,9 @@ async def test_reconcile_deduplicates_source_paths(docker_compose: DependencyPor
             subscription_type_id=1,
             sources=[first, second],
         )
-        assert result.discovered == result.created == 1
+        assert_that((result.discovered, result.created), equal_to((1, 1)))
         media, *_ = await get_category_media_by_subscription_types([1])
-        assert media.source_revision == second.source_revision
+        assert_that(media.source_revision, equal_to(second.source_revision))
 
 
 def _source(path: str, *, revision: str) -> CategoryMediaSource:

--- a/tests/functional/test_inline_latency_baseline.py
+++ b/tests/functional/test_inline_latency_baseline.py
@@ -9,6 +9,7 @@ from functools import partial
 from typing import Any
 
 import pytest
+from hamcrest import assert_that, equal_to, has_length
 
 from cringe_pics_telebot.services.media_sync import MediaSyncSummary
 from tests.functional.conftest import (
@@ -205,7 +206,7 @@ async def _measure_scenario(
             "answerInlineQuery",
             predicate=partial(_has_inline_query_id, query_id=query_id),
         )
-        assert len(answer["payload"]["results"]) == expected_results
+        assert_that(answer["payload"]["results"], has_length(expected_results))
 
         measurement = {"total": float((await fake_statsd_server.wait_for_metric("functional.inline.total"))["value"])}
         for stage in stages:
@@ -214,7 +215,7 @@ async def _measure_scenario(
         for name, expected_value in expected_counts.items():
             metric = await fake_statsd_server.wait_for_metric(f"functional.inline.{name}")
             value = int(metric["value"])
-            assert value == expected_value
+            assert_that(value, equal_to(expected_value))
             if run == 0:
                 observed_counts[name] = value
         measurements.append(measurement)

--- a/tests/functional/test_media_sync.py
+++ b/tests/functional/test_media_sync.py
@@ -2,6 +2,7 @@ from collections.abc import Awaitable, Callable
 from datetime import time, timedelta
 
 import pytest
+from hamcrest import assert_that, empty, equal_to, is_, same_instance
 
 from cringe_pics_telebot.repositories import redis as cache
 from cringe_pics_telebot.repositories.postgres import (
@@ -60,9 +61,9 @@ async def test_sync_reconciles_changes_isolates_failures_and_honors_lease(
         ),
     ):
         first = await synchronize_media_catalog()
-        assert first.categories == 2
-        assert first.failed == 0
-        assert first.discovered == first.created == 3
+        assert_that(first.categories, equal_to(2))
+        assert_that(first.failed, equal_to(0))
+        assert_that((first.discovered, first.created), equal_to((3, 3)))
 
         await fake_yandex_server.configure_directory(
             "day",
@@ -74,18 +75,18 @@ async def test_sync_reconciles_changes_isolates_failures_and_honors_lease(
         await fake_yandex_server.configure_directory("broken", fail=True)
 
         second = await synchronize_media_catalog()
-        assert second.categories == 1
-        assert second.failed == 1
-        assert second.discovered == 2
-        assert second.created == second.changed == second.deactivated == 1
+        assert_that(second.categories, equal_to(1))
+        assert_that(second.failed, equal_to(1))
+        assert_that(second.discovered, equal_to(2))
+        assert_that((second.created, second.changed, second.deactivated), equal_to((1, 1, 1)))
 
         media = await get_category_media_by_subscription_types([1, 2], active_only=False)
         by_path = {item.source_path: item for item in media}
-        assert by_path["day/image.png"].source_revision == "sha256:changed"
-        assert by_path["day/image.png"].status is CategoryMediaStatus.pending
-        assert by_path["day/second.png"].status is CategoryMediaStatus.inactive
-        assert by_path["day/third.png"].status is CategoryMediaStatus.pending
-        assert by_path["broken/image.png"].is_active is True
+        assert_that(by_path["day/image.png"].source_revision, equal_to("sha256:changed"))
+        assert_that(by_path["day/image.png"].status, same_instance(CategoryMediaStatus.pending))
+        assert_that(by_path["day/second.png"].status, same_instance(CategoryMediaStatus.inactive))
+        assert_that(by_path["day/third.png"].status, same_instance(CategoryMediaStatus.pending))
+        assert_that(by_path["broken/image.png"].is_active, is_(True))
 
         await cache.set(
             key=MEDIA_SYNC_LEASE_KEY,
@@ -95,8 +96,11 @@ async def test_sync_reconciles_changes_isolates_failures_and_honors_lease(
         )
         requests_before_skip = len(await fake_yandex_server.requests())
         skipped = await synchronize_media_catalog()
-        assert skipped.acquired is False
-        assert len(await fake_yandex_server.requests()) == requests_before_skip
+        assert_that(skipped.acquired, is_(False))
+        assert_that(len(await fake_yandex_server.requests()), equal_to(requests_before_skip))
 
     requests = await fake_yandex_server.requests()
-    assert not any(request["method"] in {"resources/download", "download"} for request in requests)
+    assert_that(
+        {request["method"] for request in requests} & {"resources/download", "download"},
+        empty(),
+    )

--- a/tests/functional/test_subscription_broadcasts.py
+++ b/tests/functional/test_subscription_broadcasts.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, time
 from typing import Any
 
 import pytest
+from hamcrest import assert_that, empty, equal_to, has_item
 
 from cringe_pics_telebot.services.media_sync import MediaSyncSummary
 from tests.functional.conftest import (
@@ -41,22 +42,27 @@ async def test_subscription_broadcasts_use_each_users_local_time_without_duplica
     await synchronize_functional_media_catalog()
     await fake_yandex_server.reset()
 
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)) == 1
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, 45, tzinfo=UTC)) == 0
-    assert _sent_chat_ids(await fake_telegram_server.requests(method="sendPhoto")) == [700]
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)), equal_to(1))
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, 45, tzinfo=UTC)), equal_to(0))
+    assert_that(_sent_chat_ids(await fake_telegram_server.requests(method="sendPhoto")), equal_to([700]))
 
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 6, 0, tzinfo=UTC)) == 1
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 6, 0, tzinfo=UTC)), equal_to(1))
     send_photo_requests = await fake_telegram_server.requests(method="sendPhoto")
-    assert _sent_chat_ids(send_photo_requests) == [700, 400]
-    assert [request["payload"]["photo"] for request in send_photo_requests] == [
-        f"{fake_yandex_server.base_url}/download/image.png",
-        "functional-photo-file-id",
-    ]
+    assert_that(_sent_chat_ids(send_photo_requests), equal_to([700, 400]))
+    assert_that(
+        [request["payload"]["photo"] for request in send_photo_requests],
+        equal_to(
+            [
+                f"{fake_yandex_server.base_url}/download/image.png",
+                "functional-photo-file-id",
+            ]
+        ),
+    )
 
-    yandex_requests = await fake_yandex_server.requests()
-    assert not any(request["method"] == "resources" for request in yandex_requests)
-    assert any(request["method"] == "resources/download" for request in yandex_requests)
-    assert not any(request["method"] == "download" for request in yandex_requests)
+    yandex_methods = [request["method"] for request in await fake_yandex_server.requests()]
+    assert_that([method for method in yandex_methods if method == "resources"], empty())
+    assert_that(yandex_methods, has_item("resources/download"))
+    assert_that([method for method in yandex_methods if method == "download"], empty())
 
 
 async def test_subscription_broadcasts_skip_empty_category(
@@ -76,9 +82,9 @@ async def test_subscription_broadcasts_skip_empty_category(
     await synchronize_functional_media_catalog()
     await fake_yandex_server.reset()
 
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)) == 0
-    assert not await fake_telegram_server.requests(method="sendPhoto")
-    assert not await fake_yandex_server.requests()
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)), equal_to(0))
+    assert_that(await fake_telegram_server.requests(method="sendPhoto"), empty())
+    assert_that(await fake_yandex_server.requests(), empty())
 
 
 async def test_subscription_broadcast_prefers_pending_media_over_ready(
@@ -106,17 +112,26 @@ async def test_subscription_broadcast_prefers_pending_media_over_ready(
     await fake_telegram_server.reset()
     await fake_yandex_server.reset()
 
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)) == 1
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)), equal_to(1))
 
     send_photo_requests = await fake_telegram_server.requests(method="sendPhoto")
-    assert [request["payload"]["photo"] for request in send_photo_requests] == [
-        f"{fake_yandex_server.base_url}/download/pending.png"
-    ]
-    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
-    assert await read_functional_category_media_states() == {
-        "morning/pending.png": ("ready", "functional-photo-file-id"),
-        "morning/ready.png": ("ready", "functional-ready-file-id"),
-    }
+    assert_that(
+        [request["payload"]["photo"] for request in send_photo_requests],
+        equal_to([f"{fake_yandex_server.base_url}/download/pending.png"]),
+    )
+    assert_that(
+        sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()),
+        equal_to(1),
+    )
+    assert_that(
+        await read_functional_category_media_states(),
+        equal_to(
+            {
+                "morning/pending.png": ("ready", "functional-photo-file-id"),
+                "morning/ready.png": ("ready", "functional-ready-file-id"),
+            }
+        ),
+    )
 
 
 async def test_concurrent_scheduled_recipients_materialize_one_pending_revision_once(
@@ -137,14 +152,17 @@ async def test_concurrent_scheduled_recipients_materialize_one_pending_revision_
     await synchronize_functional_media_catalog()
     await fake_yandex_server.reset()
 
-    assert await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)) == 2
+    assert_that(await run_subscription_broadcasts_at(datetime(2026, 8, 16, 3, 0, tzinfo=UTC)), equal_to(2))
 
     send_photo_requests = await fake_telegram_server.requests(method="sendPhoto")
-    assert sorted(_sent_chat_ids(send_photo_requests)) == [701, 702]
+    assert_that(sorted(_sent_chat_ids(send_photo_requests)), equal_to([701, 702]))
     sent_media = [request["payload"]["photo"] for request in send_photo_requests]
-    assert sent_media.count(f"{fake_yandex_server.base_url}/download/image.png") == 1
-    assert sent_media.count("functional-photo-file-id") == 1
-    assert sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()) == 1
+    assert_that(sent_media.count(f"{fake_yandex_server.base_url}/download/image.png"), equal_to(1))
+    assert_that(sent_media.count("functional-photo-file-id"), equal_to(1))
+    assert_that(
+        sum(request["method"] == "resources/download" for request in await fake_yandex_server.requests()),
+        equal_to(1),
+    )
 
 
 def _sent_chat_ids(requests: list[dict[str, Any]]) -> list[int]:

--- a/tests/units/test_admin_broadcast_recipients.py
+++ b/tests/units/test_admin_broadcast_recipients.py
@@ -1,4 +1,5 @@
 import pytest
+from hamcrest import assert_that, empty, equal_to
 
 from cringe_pics_telebot.services.admin_broadcast_recipients import (
     MAX_EXTRA_RECIPIENTS,
@@ -8,11 +9,11 @@ from cringe_pics_telebot.services.admin_broadcast_recipients import (
 
 
 def test_parse_recipient_ids_with_supported_separators_and_duplicates() -> None:
-    assert parse_admin_broadcast_recipient_ids("700, 400\n700;900") == {400, 700, 900}
+    assert_that(parse_admin_broadcast_recipient_ids("700, 400\n700;900"), equal_to({400, 700, 900}))
 
 
 def test_dash_clears_recipient_ids() -> None:
-    assert parse_admin_broadcast_recipient_ids(" - ") == set()
+    assert_that(parse_admin_broadcast_recipient_ids(" - "), empty())
 
 
 @pytest.mark.parametrize("value", ["", "abc", "-1", "0", str(2**63)])

--- a/tests/units/test_admin_broadcast_schedules.py
+++ b/tests/units/test_admin_broadcast_schedules.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 import pytest
+from hamcrest import assert_that, equal_to, none
 
 from cringe_pics_telebot.services.admin_broadcast_schedules import (
     InvalidAdminBroadcastScheduleError,
@@ -17,10 +18,11 @@ def test_parse_local_recipient_schedule() -> None:
         now=datetime(2026, 8, 19, 21, 0, tzinfo=UTC),
     )
 
-    assert schedule.local_at == datetime(2026, 8, 20, 10, 30)
-    assert schedule.timezone_offset_minutes is None
-    assert format_admin_broadcast_schedule(schedule.local_at, schedule.timezone_offset_minutes) == (
-        "20.08.2026 10:30 — локальное время каждого получателя"
+    assert_that(schedule.local_at, equal_to(datetime(2026, 8, 20, 10, 30)))
+    assert_that(schedule.timezone_offset_minutes, none())
+    assert_that(
+        format_admin_broadcast_schedule(schedule.local_at, schedule.timezone_offset_minutes),
+        equal_to("20.08.2026 10:30 — локальное время каждого получателя"),
     )
 
 
@@ -30,10 +32,11 @@ def test_parse_fixed_timezone_override() -> None:
         now=datetime(2026, 8, 20, 15, 0, tzinfo=UTC),
     )
 
-    assert schedule.local_at == datetime(2026, 8, 20, 10, 30)
-    assert schedule.timezone_offset_minutes == -330
-    assert format_admin_broadcast_schedule(schedule.local_at, schedule.timezone_offset_minutes) == (
-        "20.08.2026 10:30 · UTC-05:30"
+    assert_that(schedule.local_at, equal_to(datetime(2026, 8, 20, 10, 30)))
+    assert_that(schedule.timezone_offset_minutes, equal_to(-330))
+    assert_that(
+        format_admin_broadcast_schedule(schedule.local_at, schedule.timezone_offset_minutes),
+        equal_to("20.08.2026 10:30 · UTC-05:30"),
     )
 
 
@@ -123,12 +126,12 @@ def test_format_admin_broadcast_countdown(
     now: datetime,
     expected: str,
 ) -> None:
-    assert (
+    assert_that(
         format_admin_broadcast_countdown(
             local_at,
             timezone_offset_minutes,
             viewer_timezone_offset_minutes=viewer_timezone_offset_minutes,
             now=now,
-        )
-        == expected
+        ),
+        equal_to(expected),
     )

--- a/tests/units/test_admin_broadcasts.py
+++ b/tests/units/test_admin_broadcasts.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
 
+from hamcrest import assert_that, is_
+
 from cringe_pics_telebot.repositories.postgres.entities import (
     AdminBroadcast,
     AdminBroadcastStatus,
@@ -15,8 +17,8 @@ def test_broadcast_without_override_uses_each_users_timezone() -> None:
     broadcast = _broadcast(scheduled_local_at=datetime(2026, 8, 17, 10, 0))
     current_time = datetime(2026, 8, 17, 3, 0, tzinfo=UTC)
 
-    assert is_admin_broadcast_due(broadcast, user=_user(700, 420), now=current_time)
-    assert not is_admin_broadcast_due(broadcast, user=_user(400, 240), now=current_time)
+    assert_that(is_admin_broadcast_due(broadcast, user=_user(700, 420), now=current_time), is_(True))
+    assert_that(is_admin_broadcast_due(broadcast, user=_user(400, 240), now=current_time), is_(False))
 
 
 def test_broadcast_override_uses_one_fixed_timezone_for_all_users() -> None:
@@ -26,21 +28,27 @@ def test_broadcast_override_uses_one_fixed_timezone_for_all_users() -> None:
     )
     current_time = datetime(2026, 8, 17, 3, 0, tzinfo=UTC)
 
-    assert is_admin_broadcast_due(broadcast, user=_user(700, 420), now=current_time)
-    assert is_admin_broadcast_due(broadcast, user=_user(400, 240), now=current_time)
-    assert is_admin_broadcast_due(broadcast, user=_user(-500, -300), now=current_time)
+    assert_that(is_admin_broadcast_due(broadcast, user=_user(700, 420), now=current_time), is_(True))
+    assert_that(is_admin_broadcast_due(broadcast, user=_user(400, 240), now=current_time), is_(True))
+    assert_that(is_admin_broadcast_due(broadcast, user=_user(-500, -300), now=current_time), is_(True))
 
 
 def test_local_broadcast_completes_only_after_latest_supported_timezone() -> None:
     broadcast = _broadcast(scheduled_local_at=datetime(2026, 8, 17, 10, 0))
 
-    assert not is_admin_broadcast_complete(
-        broadcast,
-        now=datetime(2026, 8, 17, 21, 59, tzinfo=UTC),
+    assert_that(
+        is_admin_broadcast_complete(
+            broadcast,
+            now=datetime(2026, 8, 17, 21, 59, tzinfo=UTC),
+        ),
+        is_(False),
     )
-    assert is_admin_broadcast_complete(
-        broadcast,
-        now=datetime(2026, 8, 17, 22, 0, tzinfo=UTC),
+    assert_that(
+        is_admin_broadcast_complete(
+            broadcast,
+            now=datetime(2026, 8, 17, 22, 0, tzinfo=UTC),
+        ),
+        is_(True),
     )
 
 

--- a/tests/units/test_category_aliases.py
+++ b/tests/units/test_category_aliases.py
@@ -1,4 +1,5 @@
 import pytest
+from hamcrest import assert_that, equal_to
 
 from cringe_pics_telebot.services.category_aliases import (
     InvalidCategoryAliasesError,
@@ -7,10 +8,9 @@ from cringe_pics_telebot.services.category_aliases import (
 
 
 def test_parse_category_search_aliases_preserves_first_unique_spelling() -> None:
-    assert parse_category_search_aliases("  полдень  \n/ДЕНЬ\nдень\n\n с обеда \n / \nПОЛДЕНЬ") == (
-        "полдень",
-        "/ДЕНЬ",
-        "с обеда",
+    assert_that(
+        parse_category_search_aliases("  полдень  \n/ДЕНЬ\nдень\n\n с обеда \n / \nПОЛДЕНЬ"),
+        equal_to(("полдень", "/ДЕНЬ", "с обеда")),
     )
 
 

--- a/tests/units/test_inline.py
+++ b/tests/units/test_inline.py
@@ -14,7 +14,7 @@ from aiogram.types import (
     InlineQueryResultPhoto,
     InlineQueryResultUnion,
 )
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, empty, equal_to, has_length, is_, not_, same_instance
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.bot import inline, keyboards
@@ -43,7 +43,7 @@ def test_category_matches_query(
     search_aliases: tuple[str, ...],
     matches: bool,
 ) -> None:
-    assert inline.category_matches_query(query, category, search_aliases) is matches
+    assert_that(inline.category_matches_query(query, category, search_aliases), is_(matches))
 
 
 @pytest.mark.parametrize("query", ["", "   ", " / "])
@@ -73,7 +73,10 @@ async def test_find_subscription_types_returns_every_matching_category(monkeypat
 
     monkeypatch.setattr(inline, "get_subscription_types", get_subscription_types)
 
-    assert await inline._find_subscription_types(" /ОБЩ ") == [subscription_types[0], subscription_types[2]]
+    assert_that(
+        await inline._find_subscription_types(" /ОБЩ "),
+        equal_to([subscription_types[0], subscription_types[2]]),
+    )
 
 
 async def test_get_inline_results_combines_categories_without_duplicate_paths(monkeypatch: MonkeyPatch) -> None:
@@ -83,7 +86,7 @@ async def test_get_inline_results_combines_categories_without_duplicate_paths(mo
     async def get_inline_images(
         subscription_types: list[SubscriptionType],
     ) -> list[tuple[SubscriptionType, CachedMedia | LinkedMedia]]:
-        assert subscription_types == [morning, evening]
+        assert_that(subscription_types, equal_to([morning, evening]))
         return [
             (
                 morning,
@@ -132,10 +135,10 @@ async def test_get_inline_results_combines_categories_without_duplicate_paths(mo
     results = await inline._get_inline_results([morning, evening])
     payloads = [result.model_dump(exclude_none=True) for result in results]
 
-    assert [payload["title"] for payload in payloads] == ["shared.png", "morning.png", "evening.png"]
-    assert payloads[0]["description"] == "Категория /morning"
-    assert payloads[2]["description"] == "Категория /evening"
-    assert len({payload["id"] for payload in payloads}) == 3
+    assert_that([payload["title"] for payload in payloads], equal_to(["shared.png", "morning.png", "evening.png"]))
+    assert_that(payloads[0]["description"], equal_to("Категория /morning"))
+    assert_that(payloads[2]["description"], equal_to("Категория /evening"))
+    assert_that({payload["id"] for payload in payloads}, has_length(3))
 
 
 def test_build_inline_category_results_preserves_media_types_and_namespaces_category_ids() -> None:
@@ -244,9 +247,9 @@ def test_shuffle_inline_results_uses_injected_shuffler_on_a_copy() -> None:
 
     shuffled_results = inline._shuffle_inline_results(results, shuffler=reverse)
 
-    assert shuffled_inputs == [["result-0", "result-1", "result-2"]]
-    assert [result.id for result in shuffled_results] == ["result-2", "result-1", "result-0"]
-    assert [result.id for result in results] == ["result-0", "result-1", "result-2"]
+    assert_that(shuffled_inputs, equal_to([["result-0", "result-1", "result-2"]]))
+    assert_that([result.id for result in shuffled_results], equal_to(["result-2", "result-1", "result-0"]))
+    assert_that([result.id for result in results], equal_to(["result-0", "result-1", "result-2"]))
 
 
 def test_prepare_inline_results_chooses_before_limit_and_deduplicates_selected_media() -> None:
@@ -269,19 +272,27 @@ def test_prepare_inline_results_chooses_before_limit_and_deduplicates_selected_m
     )
     random_result = cast(InlineQueryResultPhoto, prepared_results[0])
 
-    assert chooser_inputs == [[f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 2)]]
-    assert shuffler_inputs == [[f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 1)]]
-    assert len(prepared_results) == inline.MAX_INLINE_QUERY_RESULTS
-    assert random_result.title == inline.RANDOM_INLINE_RESULT_TITLE
-    assert len(random_result.id) == 64
-    assert random_result.id not in {result.id for result in results}
-    assert random_result.photo_url == "https://storage.example/51.png"
-    assert [result.id for result in prepared_results[1:]] == [
-        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS, 1, -1)
-    ]
-    assert [result.id for result in results] == [
-        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 2)
-    ]
+    assert_that(
+        chooser_inputs,
+        equal_to([[f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 2)]]),
+    )
+    assert_that(
+        shuffler_inputs,
+        equal_to([[f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 1)]]),
+    )
+    assert_that(prepared_results, has_length(inline.MAX_INLINE_QUERY_RESULTS))
+    assert_that(random_result.title, equal_to(inline.RANDOM_INLINE_RESULT_TITLE))
+    assert_that(random_result.id, has_length(64))
+    assert_that(random_result.id in tuple(result.id for result in results), is_(False))
+    assert_that(random_result.photo_url, equal_to("https://storage.example/51.png"))
+    assert_that(
+        [result.id for result in prepared_results[1:]],
+        equal_to([f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS, 1, -1)]),
+    )
+    assert_that(
+        [result.id for result in results],
+        equal_to([f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 2)]),
+    )
 
 
 def test_prepare_inline_results_prefers_cached_for_random_and_keeps_status_groups() -> None:
@@ -317,15 +328,15 @@ def test_prepare_inline_results_prefers_cached_for_random_and_keeps_status_group
     )
     random_result = cast(InlineQueryResultCachedPhoto, prepared[0])
 
-    assert chooser_inputs == [["cached-1", "cached-2"]]
-    assert shuffler_inputs == [["cached-1"], ["linked-1", "linked-2"]]
-    assert random_result.photo_file_id == "telegram-2"
-    assert random_result.title == inline.RANDOM_INLINE_RESULT_TITLE
-    assert [result.id for result in prepared[1:]] == ["cached-1", "linked-2", "linked-1"]
+    assert_that(chooser_inputs, equal_to([["cached-1", "cached-2"]]))
+    assert_that(shuffler_inputs, equal_to([["cached-1"], ["linked-1", "linked-2"]]))
+    assert_that(random_result.photo_file_id, equal_to("telegram-2"))
+    assert_that(random_result.title, equal_to(inline.RANDOM_INLINE_RESULT_TITLE))
+    assert_that([result.id for result in prepared[1:]], equal_to(["cached-1", "linked-2", "linked-1"]))
 
 
 def test_prepare_inline_results_returns_empty_results() -> None:
-    assert inline._prepare_inline_results([]) == []
+    assert_that(inline._prepare_inline_results([]), empty())
 
 
 @pytest.mark.parametrize(
@@ -348,13 +359,13 @@ def test_prepare_inline_results_returns_empty_results() -> None:
 def test_prepare_inline_results_preserves_selected_media_type_and_source(result: inline.InlineMediaResult) -> None:
     prepared_result = inline._prepare_inline_results([result])[0]
 
-    assert type(prepared_result) is type(result)
-    assert prepared_result.model_dump(exclude={"id", "title"}, exclude_none=True) == result.model_dump(
-        exclude={"id", "title"},
-        exclude_none=True,
+    assert_that(type(prepared_result), same_instance(type(result)))
+    assert_that(
+        prepared_result.model_dump(exclude={"id", "title"}, exclude_none=True),
+        equal_to(result.model_dump(exclude={"id", "title"}, exclude_none=True)),
     )
-    assert prepared_result.title == inline.RANDOM_INLINE_RESULT_TITLE
-    assert prepared_result.id != result.id
+    assert_that(prepared_result.title, equal_to(inline.RANDOM_INLINE_RESULT_TITLE))
+    assert_that(prepared_result.id, not_(equal_to(result.id)))
 
 
 @pytest.mark.parametrize("query_text", ["", "   ", " / "])
@@ -400,11 +411,11 @@ async def test_answer_inline_query_prepares_results_and_disables_telegram_cache(
     query = _FakeInlineQuery(query="day")
 
     async def find_subscription_types(query: str) -> list[SubscriptionType]:
-        assert query == "day"
+        assert_that(query, equal_to("day"))
         return [subscription_type]
 
     async def get_inline_results(subscription_types: list[SubscriptionType]) -> list[inline.InlineMediaResult]:
-        assert subscription_types == [subscription_type]
+        assert_that(subscription_types, equal_to([subscription_type]))
         return results
 
     def reverse(items: list[inline.InlineMediaResult]) -> None:
@@ -420,18 +431,23 @@ async def test_answer_inline_query_prepares_results_and_disables_telegram_cache(
 
     await inline.answer_inline_query(cast(InlineQuery, query))
 
-    assert len(query.results) == inline.MAX_INLINE_QUERY_RESULTS
-    assert len(query.results[0].id) == 64
-    assert query.results[0].id not in {result.id for result in results}
-    assert cast(inline.InlineMediaResult, query.results[0]).title == inline.RANDOM_INLINE_RESULT_TITLE
-    assert [result.id for result in query.results[1:]] == [
-        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS - 1, 0, -1)
-    ]
-    assert query.cache_time == 0
-    assert query.is_personal is True
-    assert [result.id for result in results] == [
-        f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 1)
-    ]
+    assert_that(query.results, has_length(inline.MAX_INLINE_QUERY_RESULTS))
+    assert_that(query.results[0].id, has_length(64))
+    assert_that(query.results[0].id in tuple(result.id for result in results), is_(False))
+    assert_that(
+        cast(inline.InlineMediaResult, query.results[0]).title,
+        equal_to(inline.RANDOM_INLINE_RESULT_TITLE),
+    )
+    assert_that(
+        [result.id for result in query.results[1:]],
+        equal_to([f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS - 1, 0, -1)]),
+    )
+    assert_that(query.cache_time, equal_to(0))
+    assert_that(query.is_personal is True, is_(True))
+    assert_that(
+        [result.id for result in results],
+        equal_to([f"result-{index}" for index in range(inline.MAX_INLINE_QUERY_RESULTS + 1)]),
+    )
 
 
 async def test_answer_inline_query_records_handled_result_error(
@@ -453,10 +469,10 @@ async def test_answer_inline_query_records_handled_result_error(
     with caplog.at_level(logging.INFO):
         await inline.answer_inline_query(cast(InlineQuery, query))
 
-    assert query.results == []
+    assert_that(query.results, empty())
     event = _last_inline_metrics_event(caplog)
-    assert event["outcome"] == "handled_error"
-    assert event["counts"]["telegram_calls"] == 1
+    assert_that(event["outcome"], equal_to("handled_error"))
+    assert_that(event["counts"]["telegram_calls"], equal_to(1))
 
 
 async def test_answer_inline_query_records_and_propagates_unhandled_error(
@@ -474,8 +490,8 @@ async def test_answer_inline_query_records_and_propagates_unhandled_error(
         await inline.answer_inline_query(cast(InlineQuery, query))
 
     event = _last_inline_metrics_event(caplog)
-    assert event["outcome"] == "unhandled_error"
-    assert event["counts"]["telegram_calls"] == 0
+    assert_that(event["outcome"], equal_to("unhandled_error"))
+    assert_that(event["counts"]["telegram_calls"], equal_to(0))
 
 
 async def test_answer_inline_query_records_and_propagates_cancellation(
@@ -493,8 +509,8 @@ async def test_answer_inline_query_records_and_propagates_cancellation(
         await inline.answer_inline_query(cast(InlineQuery, query))
 
     event = _last_inline_metrics_event(caplog)
-    assert event["outcome"] == "cancelled"
-    assert event["counts"]["telegram_calls"] == 0
+    assert_that(event["outcome"], equal_to("cancelled"))
+    assert_that(event["counts"]["telegram_calls"], equal_to(0))
 
 
 async def _async_result[T](value: T) -> T:

--- a/tests/units/test_inline_images.py
+++ b/tests/units/test_inline_images.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, MutableSequence, Sequence
 from datetime import UTC, datetime, time
 
-from hamcrest import assert_that, equal_to, has_properties, instance_of
+from hamcrest import assert_that, empty, equal_to, has_length, has_properties, instance_of, is_, only_contains
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.repositories.postgres import (
@@ -22,7 +22,7 @@ async def test_get_inline_images_uses_catalog_ids_and_resolves_only_pending_urls
     requested_paths: list[str] = []
 
     async def get_media(category_ids: list[int]) -> list[CategoryMedia]:
-        assert category_ids == [2]
+        assert_that(category_ids, equal_to([2]))
         return media
 
     async def get_urls(paths: Iterable[str]) -> list[str | None]:
@@ -34,37 +34,47 @@ async def test_get_inline_images_uses_catalog_ids_and_resolves_only_pending_urls
 
     subscription_type = _subscription_type()
     with InlineQueryMetrics.start(query_is_empty=False, clock=lambda: 1) as metrics:
-        assert await inline_images.get_inline_images([subscription_type], shuffler=_keep_order) == [
-            (
-                subscription_type,
-                CachedMedia(
-                    name="1.png",
-                    mime_type="image/png",
-                    path="day/1.png",
-                    source_revision="sha256:1",
-                    id="telegram-file-id",
-                ),
+        assert_that(
+            await inline_images.get_inline_images([subscription_type], shuffler=_keep_order),
+            equal_to(
+                [
+                    (
+                        subscription_type,
+                        CachedMedia(
+                            name="1.png",
+                            mime_type="image/png",
+                            path="day/1.png",
+                            source_revision="sha256:1",
+                            id="telegram-file-id",
+                        ),
+                    ),
+                    (
+                        subscription_type,
+                        LinkedMedia(
+                            name="2.png",
+                            mime_type="image/png",
+                            path="day/2.png",
+                            source_revision="sha256:2",
+                            url="https://storage.example/day/2.png",
+                        ),
+                    ),
+                ]
             ),
-            (
-                subscription_type,
-                LinkedMedia(
-                    name="2.png",
-                    mime_type="image/png",
-                    path="day/2.png",
-                    source_revision="sha256:2",
-                    url="https://storage.example/day/2.png",
-                ),
-            ),
-        ]
-    assert requested_paths == ["day/2.png"]
-    assert metrics.counts.catalog_media == 2
-    assert metrics.counts.selected_media == 2
-    assert metrics.counts.ready_media == 1
-    assert metrics.counts.pending_media == 1
-    assert metrics.counts.url_successes == 1
-    assert metrics.counts.url_failures == 0
-    assert metrics.counts.postgres_calls == 1
-    assert metrics.counts.yandex_calls == 1
+        )
+    assert_that(requested_paths, equal_to(["day/2.png"]))
+    assert_that(
+        metrics.counts,
+        has_properties(
+            catalog_media=2,
+            selected_media=2,
+            ready_media=1,
+            pending_media=1,
+            url_successes=1,
+            url_failures=0,
+            postgres_calls=1,
+            yandex_calls=1,
+        ),
+    )
 
 
 async def test_get_inline_images_applies_global_limit_before_resolving_urls(monkeypatch: MonkeyPatch) -> None:
@@ -84,8 +94,8 @@ async def test_get_inline_images_applies_global_limit_before_resolving_urls(monk
 
     results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
 
-    assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
-    assert requested_paths == [f"day/{index}.png" for index in range(50)]
+    assert_that(results, has_length(inline_images.MAX_INLINE_QUERY_RESULTS))
+    assert_that(requested_paths, equal_to([f"day/{index}.png" for index in range(50)]))
 
 
 async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: MonkeyPatch) -> None:
@@ -102,18 +112,23 @@ async def test_get_inline_images_skips_only_missing_download_url(monkeypatch: Mo
     )
 
     subscription_type = _subscription_type()
-    assert await inline_images.get_inline_images([subscription_type], shuffler=_keep_order) == [
-        (
-            subscription_type,
-            LinkedMedia(
-                name="1.png",
-                mime_type="image/png",
-                path="day/1.png",
-                source_revision="sha256:1",
-                url="https://storage.example/day/1.png",
-            ),
-        )
-    ]
+    assert_that(
+        await inline_images.get_inline_images([subscription_type], shuffler=_keep_order),
+        equal_to(
+            [
+                (
+                    subscription_type,
+                    LinkedMedia(
+                        name="1.png",
+                        mime_type="image/png",
+                        path="day/1.png",
+                        source_revision="sha256:1",
+                        url="https://storage.example/day/1.png",
+                    ),
+                )
+            ]
+        ),
+    )
 
 
 async def test_get_inline_images_uses_only_ready_when_ready_fills_limit(
@@ -136,9 +151,9 @@ async def test_get_inline_images_uses_only_ready_when_ready_fills_limit(
 
     results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
 
-    assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
-    assert all(isinstance(image, CachedMedia) for _, image in results)
-    assert url_resolution_attempted is False
+    assert_that(results, has_length(inline_images.MAX_INLINE_QUERY_RESULTS))
+    assert_that([isinstance(image, CachedMedia) for _, image in results], only_contains(True))
+    assert_that(url_resolution_attempted, is_(False))
 
 
 async def test_get_inline_images_fills_only_remaining_places_with_pending(
@@ -163,10 +178,10 @@ async def test_get_inline_images_fills_only_remaining_places_with_pending(
 
     results = await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order)
 
-    assert len(results) == inline_images.MAX_INLINE_QUERY_RESULTS
-    assert sum(isinstance(image, CachedMedia) for _, image in results) == 48
-    assert sum(isinstance(image, LinkedMedia) for _, image in results) == 2
-    assert requested_paths == ["day/48.png", "day/49.png"]
+    assert_that(results, has_length(inline_images.MAX_INLINE_QUERY_RESULTS))
+    assert_that(sum(isinstance(image, CachedMedia) for _, image in results), equal_to(48))
+    assert_that(sum(isinstance(image, LinkedMedia) for _, image in results), equal_to(2))
+    assert_that(requested_paths, equal_to(["day/48.png", "day/49.png"]))
 
 
 async def test_get_inline_images_prefers_ready_duplicate_across_categories(
@@ -191,18 +206,23 @@ async def test_get_inline_images_prefers_ready_duplicate_across_categories(
 
     results = await inline_images.get_inline_images([morning, day], shuffler=_keep_order)
 
-    assert results == [
-        (
-            day,
-            CachedMedia(
-                name="2.png",
-                mime_type="image/png",
-                path="shared/image.png",
-                source_revision="sha256:2",
-                id="telegram-shared",
-            ),
-        )
-    ]
+    assert_that(
+        results,
+        equal_to(
+            [
+                (
+                    day,
+                    CachedMedia(
+                        name="2.png",
+                        mime_type="image/png",
+                        path="shared/image.png",
+                        source_revision="sha256:2",
+                        id="telegram-shared",
+                    ),
+                )
+            ]
+        ),
+    )
 
 
 def test_select_inline_media_shuffles_ready_and_pending_independently() -> None:
@@ -225,8 +245,8 @@ def test_select_inline_media_shuffles_ready_and_pending_independently() -> None:
         shuffler=reverse,
     )
 
-    assert shuffled_inputs == [[1, 2], [3, 4]]
-    assert [item.id for item in selected] == [2, 1, 4, 3]
+    assert_that(shuffled_inputs, equal_to([[1, 2], [3, 4]]))
+    assert_that([item.id for item in selected], equal_to([2, 1, 4, 3]))
 
 
 async def test_get_inline_images_returns_empty_without_url_resolution(
@@ -238,7 +258,7 @@ async def test_get_inline_images_returns_empty_without_url_resolution(
         lambda category_ids: _async_result([]),
     )
 
-    assert await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order) == []
+    assert_that(await inline_images.get_inline_images([_subscription_type()], shuffler=_keep_order), empty())
 
 
 async def test_get_inline_category_images_selects_one_per_nonempty_category_and_prefers_ready(

--- a/tests/units/test_inline_metrics.py
+++ b/tests/units/test_inline_metrics.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Iterable
 
 import pytest
+from hamcrest import assert_that, equal_to, has_items, has_length
 
 from cringe_pics_telebot.helpers.metrics import CounterMetric, Metric, TimingMetric
 from cringe_pics_telebot.services.inline_metrics import (
@@ -42,47 +43,58 @@ def test_inline_metrics_emit_correlated_stage_scenario_and_dependency_data(
                 pass
         metrics.finish()
 
-    assert len(sink.batches) == 1
+    assert_that(sink.batches, has_length(1))
     emitted = sink.batches[0]
-    assert CounterMetric("inline.requests") in emitted
-    assert CounterMetric("inline.outcomes.partial_error.requests") in emitted
-    assert CounterMetric("inline.scenarios.mixed.requests") in emitted
-    assert CounterMetric("inline.category_sets.multiple.requests") in emitted
-    assert CounterMetric("inline.catalog_sizes.small.requests") in emitted
-    assert CounterMetric("inline.dependencies.postgres.calls", 2) in emitted
-    assert CounterMetric("inline.dependencies.yandex.calls", 2) in emitted
-    assert CounterMetric("inline.dependencies.redis.calls", 0) in emitted
-    assert CounterMetric("inline.dependencies.telegram.calls", 1) in emitted
+    counters = [metric for metric in emitted if isinstance(metric, CounterMetric)]
+    assert_that(
+        counters,
+        has_items(
+            CounterMetric("inline.requests"),
+            CounterMetric("inline.outcomes.partial_error.requests"),
+            CounterMetric("inline.scenarios.mixed.requests"),
+            CounterMetric("inline.category_sets.multiple.requests"),
+            CounterMetric("inline.catalog_sizes.small.requests"),
+            CounterMetric("inline.dependencies.postgres.calls", 2),
+            CounterMetric("inline.dependencies.yandex.calls", 2),
+            CounterMetric("inline.dependencies.redis.calls", 0),
+            CounterMetric("inline.dependencies.telegram.calls", 1),
+        ),
+    )
     timings = {metric.name: metric.milliseconds for metric in emitted if isinstance(metric, TimingMetric)}
-    assert timings["inline.stages.categories.lookup"] == pytest.approx(100)
-    assert timings["inline.total"] == pytest.approx(500)
+    assert_that(timings["inline.stages.categories.lookup"], equal_to(pytest.approx(100)))
+    assert_that(timings["inline.total"], equal_to(pytest.approx(500)))
 
     event = json.loads(caplog.messages[-1])
-    assert event == {
-        "catalog_size": "small",
-        "category_set": "multiple",
-        "correlation_id": "correlation-1",
-        "counts": {
-            "catalog_media": 3,
-            "matched_categories": 2,
-            "pending_media": 2,
-            "postgres_calls": 2,
-            "ready_media": 1,
-            "redis_calls": 0,
-            "results_prepared": 2,
-            "results_sent": 2,
-            "retries": 0,
-            "selected_media": 3,
-            "telegram_calls": 1,
-            "url_failures": 1,
-            "url_successes": 1,
-            "yandex_calls": 2,
-        },
-        "durations_ms": {"categories.lookup": 100.0, "total": 500.0},
-        "event": "inline_query_metrics",
-        "outcome": "partial_error",
-        "scenario": "mixed",
-    }
+    assert_that(
+        event,
+        equal_to(
+            {
+                "catalog_size": "small",
+                "category_set": "multiple",
+                "correlation_id": "correlation-1",
+                "counts": {
+                    "catalog_media": 3,
+                    "matched_categories": 2,
+                    "pending_media": 2,
+                    "postgres_calls": 2,
+                    "ready_media": 1,
+                    "redis_calls": 0,
+                    "results_prepared": 2,
+                    "results_sent": 2,
+                    "retries": 0,
+                    "selected_media": 3,
+                    "telegram_calls": 1,
+                    "url_failures": 1,
+                    "url_successes": 1,
+                    "yandex_calls": 2,
+                },
+                "durations_ms": {"categories.lookup": 100.0, "total": 500.0},
+                "event": "inline_query_metrics",
+                "outcome": "partial_error",
+                "scenario": "mixed",
+            }
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -112,9 +124,9 @@ def test_inline_metrics_classify_low_cardinality_scenarios(
         metrics.counts.ready_media = ready
         metrics.counts.pending_media = pending
 
-        assert metrics.scenario == scenario
-        assert metrics.category_set == category_set
-        assert metrics.catalog_size == size
+        assert_that(metrics.scenario, equal_to(scenario))
+        assert_that(metrics.category_set, equal_to(category_set))
+        assert_that(metrics.catalog_size, equal_to(size))
 
 
 async def test_inline_stage_decorator_times_sync_and_async_functions() -> None:
@@ -130,13 +142,13 @@ async def test_inline_stage_decorator_times_sync_and_async_functions() -> None:
         return value + 2
 
     with InlineQueryMetrics.start(query_is_empty=True, sink=sink, clock=clock):
-        assert sync_function(1) == 2
-        assert await async_function(1) == 3
+        assert_that(sync_function(1), equal_to(2))
+        assert_that(await async_function(1), equal_to(3))
 
     emitted = sink.batches[0]
     timings = {metric.name: metric.milliseconds for metric in emitted if isinstance(metric, TimingMetric)}
-    assert timings["inline.stages.sync"] == pytest.approx(100)
-    assert timings["inline.stages.async"] == pytest.approx(200)
+    assert_that(timings["inline.stages.sync"], equal_to(pytest.approx(100)))
+    assert_that(timings["inline.stages.async"], equal_to(pytest.approx(200)))
 
 
 class _RecordingMetricsSink:

--- a/tests/units/test_media_delivery.py
+++ b/tests/units/test_media_delivery.py
@@ -8,6 +8,7 @@ import pytest
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.methods import SendPhoto
 from aiogram.types import Message
+from hamcrest import assert_that, equal_to, has_length, instance_of, same_instance
 
 from cringe_pics_telebot.repositories.postgres import (
     CategoryMedia,
@@ -36,12 +37,11 @@ async def test_ready_media_is_sent_without_redis_or_yandex(monkeypatch: pytest.M
 
     result = await media_delivery.deliver_category_media(_media(file_id="ready-file-id"), send=send)
 
-    assert result is send.return_value
-    await_args = send.await_args
-    assert await_args is not None
-    sent_media = await_args.args[0]
-    assert isinstance(sent_media, CachedMedia)
-    assert sent_media.id == "ready-file-id"
+    assert_that(result, same_instance(send.return_value))
+    assert_that(send.await_args_list, has_length(1))
+    sent_media = send.await_args_list[0].args[0]
+    assert_that(sent_media, instance_of(CachedMedia))
+    assert_that(sent_media.id, equal_to("ready-file-id"))
     acquire.assert_not_awaited()
     download.assert_not_awaited()
 
@@ -63,11 +63,10 @@ async def test_pending_media_is_materialized_after_real_send(monkeypatch: pytest
 
     await media_delivery.deliver_category_media(media, send=send)
 
-    await_args = send.await_args
-    assert await_args is not None
-    sent_media = await_args.args[0]
-    assert isinstance(sent_media, LinkedMedia)
-    assert sent_media.url == "https://media.test/image.png"
+    assert_that(send.await_args_list, has_length(1))
+    sent_media = send.await_args_list[0].args[0]
+    assert_that(sent_media, instance_of(LinkedMedia))
+    assert_that(sent_media.url, equal_to("https://media.test/image.png"))
     materialize.assert_awaited_once_with(
         media_id=media.id,
         source_revision=media.source_revision,
@@ -124,7 +123,7 @@ async def test_concurrent_delivery_uploads_pending_revision_once(monkeypatch: py
     await asyncio.gather(owner, waiter)
 
     download.assert_awaited_once()
-    assert acquire_calls == 2
+    assert_that(acquire_calls, equal_to(2))
 
 
 async def test_invalid_file_id_is_cleared_and_retried_once(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -150,8 +149,8 @@ async def test_invalid_file_id_is_cleared_and_retried_once(monkeypatch: pytest.M
     await media_delivery.deliver_category_media(ready, send=send)
 
     invalidate.assert_awaited_once_with(media_id=ready.id, telegram_file_id="invalid-file-id")
-    assert isinstance(send.await_args_list[0].args[0], CachedMedia)
-    assert isinstance(send.await_args_list[1].args[0], LinkedMedia)
+    assert_that(send.await_args_list[0].args[0], instance_of(CachedMedia))
+    assert_that(send.await_args_list[1].args[0], instance_of(LinkedMedia))
 
 
 async def test_cancellation_releases_owner_lease_without_materializing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/units/test_media_sync.py
+++ b/tests/units/test_media_sync.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, time, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
+from hamcrest import assert_that, equal_to, has_length, has_properties, is_, same_instance
 
 from cringe_pics_telebot.repositories.postgres import (
     CategoryMediaReconcileResult,
@@ -18,7 +19,7 @@ async def test_runner_synchronizes_immediately_then_waits(monkeypatch: pytest.Mo
     monkeypatch.setattr(media_sync, "synchronize_media_catalog", synchronize)
 
     async def cancel_during_sleep(seconds: float) -> None:
-        assert seconds == 43_200
+        assert_that(seconds, equal_to(43_200))
         raise asyncio.CancelledError
 
     with pytest.raises(asyncio.CancelledError):
@@ -55,14 +56,13 @@ async def test_synchronization_isolates_category_failures(monkeypatch: pytest.Mo
 
     result = await media_sync.synchronize_media_catalog()
 
-    assert result.acquired is True
-    assert result.categories == 1
-    assert result.failed == 1
-    assert result.discovered == result.created == 1
-    await_args = reconcile.await_args
-    assert await_args is not None
-    source = await_args.kwargs["sources"][0]
-    assert source.telegram_media_type is TelegramMediaType.animation
+    assert_that(result.acquired, is_(True))
+    assert_that(result.categories, equal_to(1))
+    assert_that(result.failed, equal_to(1))
+    assert_that(result, has_properties(discovered=1, created=1))
+    assert_that(reconcile.await_args_list, has_length(1))
+    source = reconcile.await_args_list[0].kwargs["sources"][0]
+    assert_that(source.telegram_media_type, same_instance(TelegramMediaType.animation))
     delete_lease.assert_awaited_once()
 
 
@@ -85,9 +85,9 @@ async def test_lost_lease_does_not_publish_snapshot(monkeypatch: pytest.MonkeyPa
 
     result = await media_sync.synchronize_media_catalog()
 
-    assert result.acquired is True
-    assert result.categories == 0
-    assert result.failed == 1
+    assert_that(result.acquired, is_(True))
+    assert_that(result.categories, equal_to(0))
+    assert_that(result.failed, equal_to(1))
     reconcile.assert_not_awaited()
 
 

--- a/tests/units/test_metrics.py
+++ b/tests/units/test_metrics.py
@@ -2,6 +2,7 @@ from types import TracebackType
 from typing import Self
 
 import pytest
+from hamcrest import assert_that, equal_to, instance_of, is_, same_instance
 
 from cringe_pics_telebot.helpers.metrics import (
     CounterMetric,
@@ -19,7 +20,7 @@ from cringe_pics_telebot.helpers.metrics import (
 def test_stopwatch_uses_injected_monotonic_clock() -> None:
     clock = iter((10.0, 10.125)).__next__
 
-    assert Stopwatch.start(clock=clock).elapsed_milliseconds() == 125
+    assert_that(Stopwatch.start(clock=clock).elapsed_milliseconds(), equal_to(125))
 
 
 def test_create_metrics_sink_disables_metrics_without_host() -> None:
@@ -32,8 +33,8 @@ def test_create_metrics_sink_disables_metrics_without_host() -> None:
 
     sink = create_metrics_sink({}, client_factory=client_factory)
 
-    assert isinstance(sink, NullMetricsSink)
-    assert factory_called is False
+    assert_that(sink, instance_of(NullMetricsSink))
+    assert_that(factory_called, is_(False))
 
 
 def test_create_metrics_sink_uses_external_endpoint_and_emits_pipeline() -> None:
@@ -60,19 +61,29 @@ def test_create_metrics_sink_uses_external_endpoint_and_emits_pipeline() -> None
         ]
     )
 
-    assert isinstance(sink, StatsDMetricsSink)
-    assert client_arguments == {
-        "host": "metrics.example.com",
-        "port": 18125,
-        "prefix": "test_bot",
-    }
-    assert client.pipeline_entered is True
-    assert client.pipeline_exited is True
-    assert client.calls == [
-        ("timing", "inline.total", 12.5),
-        ("counter", "inline.requests", 2),
-        ("gauge", "inline.results", 49),
-    ]
+    assert_that(sink, instance_of(StatsDMetricsSink))
+    assert_that(
+        client_arguments,
+        equal_to(
+            {
+                "host": "metrics.example.com",
+                "port": 18125,
+                "prefix": "test_bot",
+            }
+        ),
+    )
+    assert_that(client.pipeline_entered, is_(True))
+    assert_that(client.pipeline_exited, is_(True))
+    assert_that(
+        client.calls,
+        equal_to(
+            [
+                ("timing", "inline.total", 12.5),
+                ("counter", "inline.requests", 2),
+                ("gauge", "inline.results", 49),
+            ]
+        ),
+    )
 
 
 def test_create_metrics_sink_fails_fast_for_invalid_port() -> None:
@@ -93,8 +104,8 @@ def test_statsd_sink_fails_open_when_pipeline_fails() -> None:
 
     StatsDMetricsSink(client).emit([TimingMetric("inline.total", 10)])
 
-    assert client.pipeline_entered is True
-    assert client.pipeline_exited is True
+    assert_that(client.pipeline_entered, is_(True))
+    assert_that(client.pipeline_exited, is_(True))
 
 
 def test_configured_metrics_restores_previous_sink_and_closes_client() -> None:
@@ -105,10 +116,10 @@ def test_configured_metrics_restores_previous_sink_and_closes_client() -> None:
         {"STATSD_HOST": "metrics.example.com"},
         client_factory=lambda **kwargs: client,
     ) as configured_sink:
-        assert get_metrics_sink() is configured_sink
+        assert_that(get_metrics_sink(), same_instance(configured_sink))
 
-    assert get_metrics_sink() is previous_sink
-    assert client.closed is True
+    assert_that(get_metrics_sink(), same_instance(previous_sink))
+    assert_that(client.closed, is_(True))
 
 
 class _RecordingStatsDClient:

--- a/tests/units/test_random_image.py
+++ b/tests/units/test_random_image.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 
 import pytest
+from hamcrest import assert_that, equal_to, same_instance
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.repositories.postgres import (
@@ -27,8 +28,8 @@ def test_choose_random_image_prefers_pending_and_injects_chooser() -> None:
         chooser=choose_last,
     )
 
-    assert selected is second_pending
-    assert chooser_inputs == [[2, 3]]
+    assert_that(selected, same_instance(second_pending))
+    assert_that(chooser_inputs, equal_to([[2, 3]]))
 
 
 @pytest.mark.parametrize(
@@ -38,7 +39,7 @@ def test_choose_random_image_prefers_pending_and_injects_chooser() -> None:
 def test_choose_random_image_chooses_from_single_status(status: CategoryMediaStatus) -> None:
     media = _media(1, status=status)
 
-    assert random_image.choose_random_image([media], chooser=_choose_only) is media
+    assert_that(random_image.choose_random_image([media], chooser=_choose_only), same_instance(media))
 
 
 @pytest.mark.parametrize("statuses", [(), (CategoryMediaStatus.inactive,)])
@@ -64,8 +65,8 @@ async def test_get_random_image_fetches_category_once_and_applies_policy(
 
     monkeypatch.setattr(random_image, "get_category_media_by_subscription_types", get_media)
 
-    assert await random_image.get_random_image(7, chooser=_choose_only) is pending
-    assert requested_category_ids == [[7]]
+    assert_that(await random_image.get_random_image(7, chooser=_choose_only), same_instance(pending))
+    assert_that(requested_category_ids, equal_to([[7]]))
 
 
 def _choose_only(items: Sequence[CategoryMedia]) -> CategoryMedia:

--- a/tests/units/test_redis_key_stability.py
+++ b/tests/units/test_redis_key_stability.py
@@ -1,5 +1,7 @@
 import types
 
+from hamcrest import assert_that, equal_to, not_
+
 from cringe_pics_telebot.repositories.redis import repo
 
 
@@ -27,11 +29,11 @@ def test_make_key_is_stable_for_functions_with_same_module_and_qualname() -> Non
     # Same args -> same key
     key1 = repo._make_key(f1, 1, y=3)
     key2 = repo._make_key(f2, 1, y=3)
-    assert key1 == key2
+    assert_that(key1, equal_to(key2))
 
     # Different args -> different key
     key3 = repo._make_key(f1, 2, y=3)
-    assert key1 != key3
+    assert_that(key1, not_(equal_to(key3)))
 
     # Repeated call is stable
-    assert key1 == repo._make_key(f1, 1, y=3)
+    assert_that(key1, equal_to(repo._make_key(f1, 1, y=3)))

--- a/tests/units/test_subscription_broadcasts.py
+++ b/tests/units/test_subscription_broadcasts.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 from aiogram import Bot
+from hamcrest import assert_that, equal_to, is_
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.repositories.postgres import (
@@ -39,13 +40,13 @@ def test_same_local_minute(
     timezone_offset_minutes: int,
     expected: bool,
 ) -> None:
-    assert (
+    assert_that(
         _same_local_minute(
             scheduled_time,
             current_time,
             timezone_offset_minutes=timezone_offset_minutes,
-        )
-        is expected
+        ),
+        is_(expected),
     )
 
 
@@ -61,7 +62,7 @@ async def test_broadcast_fetches_media_once_and_prefers_pending_for_every_recipi
     delivered: list[CategoryMedia] = []
 
     async def get_users(subscription_type_id: int) -> list[User]:
-        assert subscription_type_id == subscription_type.id
+        assert_that(subscription_type_id, equal_to(subscription_type.id))
         return users
 
     async def get_media(category_ids: list[int]) -> list[CategoryMedia]:
@@ -85,9 +86,9 @@ async def test_broadcast_fetches_media_once_and_prefers_pending_for_every_recipi
         current_time=now,
     )
 
-    assert sent == 2
-    assert requested_category_ids == [[subscription_type.id]]
-    assert delivered == [pending, pending]
+    assert_that(sent, equal_to(2))
+    assert_that(requested_category_ids, equal_to([[subscription_type.id]]))
+    assert_that(delivered, equal_to([pending, pending]))
 
 
 async def test_broadcast_does_not_reserve_empty_category(monkeypatch: MonkeyPatch) -> None:
@@ -114,8 +115,8 @@ async def test_broadcast_does_not_reserve_empty_category(monkeypatch: MonkeyPatc
         current_time=datetime(2026, 8, 25, 3, 0, tzinfo=UTC),
     )
 
-    assert sent == 0
-    assert reservation_attempted is False
+    assert_that(sent, equal_to(0))
+    assert_that(reservation_attempted, is_(False))
 
 
 def _subscription_type() -> SubscriptionType:

--- a/tests/units/test_timezones.py
+++ b/tests/units/test_timezones.py
@@ -1,4 +1,5 @@
 import pytest
+from hamcrest import assert_that, equal_to
 
 from cringe_pics_telebot.services.timezones import (
     InvalidTimezoneOffsetError,
@@ -19,7 +20,7 @@ from cringe_pics_telebot.services.timezones import (
     ],
 )
 def test_parse_timezone_offset(value: str, expected: int) -> None:
-    assert parse_timezone_offset(value) == expected
+    assert_that(parse_timezone_offset(value), equal_to(expected))
 
 
 @pytest.mark.parametrize(
@@ -52,4 +53,4 @@ def test_parse_timezone_offset_rejects_invalid_values(value: str) -> None:
     ],
 )
 def test_format_timezone_offset(offset_minutes: int, expected: str) -> None:
-    assert format_timezone_offset(offset_minutes) == expected
+    assert_that(format_timezone_offset(offset_minutes), equal_to(expected))

--- a/tests/units/test_yandex_repo.py
+++ b/tests/units/test_yandex_repo.py
@@ -2,6 +2,7 @@ import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from hamcrest import assert_that, empty, equal_to, is_, starts_with
 from pytest import MonkeyPatch
 
 from cringe_pics_telebot.repositories.yandex import repo
@@ -9,7 +10,7 @@ from cringe_pics_telebot.repositories.yandex.yandex import resource_revision
 
 
 def test_resource_revision_prefers_content_hash() -> None:
-    assert (
+    assert_that(
         resource_revision(
             {
                 "sha256": "ABCDEF",
@@ -17,8 +18,8 @@ def test_resource_revision_prefers_content_hash() -> None:
                 "size": 12,
                 "modified": "2026-08-19T00:00:00+00:00",
             }
-        )
-        == "sha256:abcdef"
+        ),
+        equal_to("sha256:abcdef"),
     )
 
 
@@ -26,8 +27,8 @@ def test_resource_revision_has_deterministic_metadata_fallback() -> None:
     first = resource_revision({"size": 12, "modified": "2026-08-19T00:00:00+00:00"})
     second = resource_revision({"modified": "2026-08-19T00:00:00+00:00", "size": 12})
 
-    assert first == second
-    assert first.startswith("metadata-sha256:")
+    assert_that(first, equal_to(second))
+    assert_that(first, starts_with("metadata-sha256:"))
 
 
 async def test_get_download_urls_fetches_concurrently_and_preserves_input_order(monkeypatch: MonkeyPatch) -> None:
@@ -42,13 +43,13 @@ async def test_get_download_urls_fetches_concurrently_and_preserves_input_order(
 
     urls_task = asyncio.create_task(repo.get_download_urls(paths))
     await asyncio.wait_for(client.all_started.wait(), timeout=1)
-    assert not urls_task.done()
+    assert_that(urls_task.done(), is_(False))
 
     for path in reversed(paths):
         client.complete(path)
 
-    assert await urls_task == [f"https://storage.example/{path}" for path in paths]
-    assert client.completion_order == list(reversed(paths))
+    assert_that(await urls_task, equal_to([f"https://storage.example/{path}" for path in paths]))
+    assert_that(client.completion_order, equal_to(list(reversed(paths))))
 
 
 async def test_get_download_urls_returns_none_for_failed_lookup_after_batch_finishes(monkeypatch: MonkeyPatch) -> None:
@@ -65,10 +66,10 @@ async def test_get_download_urls_returns_none_for_failed_lookup_after_batch_fini
     await asyncio.wait_for(client.all_started.wait(), timeout=1)
     client.complete("day/broken.png")
     await asyncio.wait_for(client.completed("day/broken.png"), timeout=1)
-    assert not urls_task.done()
+    assert_that(urls_task.done(), is_(False))
 
     client.complete("day/good.png")
-    assert await urls_task == ["https://storage.example/day/good.png", None]
+    assert_that(await urls_task, equal_to(["https://storage.example/day/good.png", None]))
 
 
 async def test_get_download_urls_skips_connection_for_empty_input(monkeypatch: MonkeyPatch) -> None:
@@ -79,7 +80,7 @@ async def test_get_download_urls_skips_connection_for_empty_input(monkeypatch: M
 
     monkeypatch.setattr(repo, "get_connection", unexpected_connection)
 
-    assert await repo.get_download_urls([]) == []
+    assert_that(await repo.get_download_urls([]), empty())
 
 
 class _ControlledYandexClient:


### PR DESCRIPTION
## Summary
- rewrite unit-test assertions with PyHamcrest matchers
- rewrite functional-test and migration fixture assertions with PyHamcrest matchers
- preserve pytest exception contexts and existing test behavior

## Validation
- uv run ruff check
- uv run ruff format --check .
- uv run mypy .
- uv run pytest tests/units -q — 137 passed
- uv run pytest tests/functional -q — 50 passed, 1 skipped

## Review
- both implementation commits approved in Crit
- complete branch diff approved in Crit